### PR TITLE
Refactor: 회원가입 프로세스 간소화 및 PASS 본인인증 통합

### DIFF
--- a/.github/workflows/code-review.yml
+++ b/.github/workflows/code-review.yml
@@ -1,0 +1,19 @@
+name: Claude Assistant
+on:
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created, edited]
+  issues:
+    types: [opened, assigned, labeled]
+  pull_request_review:
+    types: [submitted]
+
+jobs:
+  claude-response:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: anthropics/claude-code-action@beta
+        with:
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/src/admin/controllers/admin-mail.controller.ts
+++ b/src/admin/controllers/admin-mail.controller.ts
@@ -17,8 +17,9 @@ export class AdminMailController {
 
   @ApiOperation({ summary: '어드민 - 사전가입 인증 메일 전송' })
   @Post('/pre-signup')
-  async sendPreSignupEmail(@Body() { email, name }: PreSignUp) {    
-    this.signService.sendPreWelcomeEmail(email, name, {} as SignupRequest);
+  async sendPreSignupEmail(@Body() { email, name }: PreSignUp) {
+    // TODO: Pass 기반 회원가입으로 변경되어 사전가입 메일 기능 비활성화
+    // this.signService.sendPreWelcomeEmail(email, name, {} as SignupRequest);
   }
 
 }

--- a/src/auth/auth.module.ts
+++ b/src/auth/auth.module.ts
@@ -17,6 +17,7 @@ import { SmsModule } from '@/sms/sms.module';
 import { AiTokenController } from './controller/ai-token.controller';
 import { AiTokenService } from './services/ai-token.service';
 import { AiUserSetupService } from './services/ai-user-setup.service';
+import { IamportService } from './services/iamport.service';
 
 @Module({
   imports: [SmsModule],
@@ -32,6 +33,7 @@ import { AiUserSetupService } from './services/ai-user-setup.service';
     S3Service,
     AiTokenService,
     AiUserSetupService,
+    IamportService,
   ],
   exports: [SignupService, AuthService, UniversityService, AiTokenService],
 })

--- a/src/auth/controller/auth.controller.ts
+++ b/src/auth/controller/auth.controller.ts
@@ -11,6 +11,7 @@ import {
 import { Response } from 'express';
 import { AuthService } from '../services/auth.service';
 import { LoginRequest, TokenResponse, WithdrawRequest } from '../dto';
+import { PassLoginRequest, PassLoginResponse } from '../dto/pass-login.dto';
 import { CurrentUser, Public, Roles } from '@auth/decorators';
 import { AuthenticationUser } from '@/types';
 import { AuthDocs } from '@auth/docs';
@@ -58,6 +59,23 @@ export class AuthController {
     const result = await this.authService.login(loginRequest);
 
     this.setRefreshTokenCookie(response, result.refreshToken);
+    return result;
+  }
+
+  @Post('pass-login')
+  @HttpCode(HttpStatus.OK)
+  @Public()
+  async passLogin(
+    @Body() passLoginRequest: PassLoginRequest,
+    @Res({ passthrough: true }) response: Response,
+  ): Promise<PassLoginResponse> {
+    const result = await this.authService.passLogin(passLoginRequest);
+
+    // 기존 사용자인 경우에만 리프레시 토큰 쿠키 설정
+    if (!result.isNewUser && result.refreshToken) {
+      this.setRefreshTokenCookie(response, result.refreshToken);
+    }
+
     return result;
   }
 

--- a/src/auth/controller/signup.controller.ts
+++ b/src/auth/controller/signup.controller.ts
@@ -1,12 +1,11 @@
-import { Body, Controller, Post, Patch, UseInterceptors, UploadedFiles, BadRequestException, HttpCode, HttpStatus } from '@nestjs/common';
+import { Body, Controller, Post, UseInterceptors, UploadedFiles, BadRequestException } from '@nestjs/common';
 import { SignupService } from '../services/signup.service';
-import { Email, InstagramId, SignupRequest } from '../dto';
+import { InstagramId, SignupRequest } from '../dto';
 import { Public } from '@auth/decorators';
 import { SignupDocs } from '../docs/signup.docs';
 import { FilesInterceptor } from '@nestjs/platform-express';
-import { ApiConsumes, ApiOperation } from '@nestjs/swagger';
+import { ApiConsumes } from '@nestjs/swagger';
 import * as multer from 'multer';
-import { SmsCodeCreation, AuthorizeSmsCode } from '../dto/signup';
 
 @Controller('auth')
 @SignupDocs.controller()
@@ -42,27 +41,7 @@ export class SignupController {
   }
 
 
-  @ApiOperation({ summary: '인증번호 전송', description: '인증번호를 전송합니다.' })
-  @Post('sms/send')
-  @HttpCode(HttpStatus.CREATED)
-  async sendSmsCode(@Body() { phoneNumber }: SmsCodeCreation) {
-    const uniqueKey = await this.signupService.sendVerificationcCode(phoneNumber);
-    return { uniqueKey };
-  }
 
-  @ApiOperation({ summary: '인증번호 인증', description: 'SMS 인증을 수행합니다.' })
-  @Patch('sms')
-  async matchSmsCode(@Body() { authorizationCode, uniqueKey }: AuthorizeSmsCode) {
-    await this.signupService.matchVerificationCode(uniqueKey, authorizationCode);
-  }
-
-
-  @Post('check/email')
-  @SignupDocs.checkEmail()
-  async checkEmail(@Body() { email }: Email) {
-    const exists = await this.signupService.checkEmail(email);
-    return { exists };
-  }
 
   @Post('check/instagram')
   async existsInstagram(@Body() { instagramId }: InstagramId) {

--- a/src/auth/dto/index.ts
+++ b/src/auth/dto/index.ts
@@ -6,6 +6,7 @@ export { SignupRequest } from './signup';
 export { LoginRequest } from './login';
 export { TokenResponse } from './token';
 export { WithdrawRequest } from './withdraw.dto';
+export { PassLoginRequest, PassLoginResponse } from './pass-login.dto';
 
 export class InstagramId {
   @ApiProperty({

--- a/src/auth/dto/pass-login.dto.ts
+++ b/src/auth/dto/pass-login.dto.ts
@@ -1,0 +1,61 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { IsString, IsNotEmpty } from 'class-validator';
+
+export class PassLoginRequest {
+  @ApiProperty({
+    description: '아임포트 본인인증 고유번호',
+    example: 'imp_123456789',
+  })
+  @IsString()
+  @IsNotEmpty()
+  impUid: string;
+}
+
+export class PassLoginResponse {
+  @ApiProperty({
+    description: '액세스 토큰',
+    example: 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...',
+  })
+  accessToken: string;
+
+  @ApiProperty({
+    description: '리프레시 토큰',
+    example: 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9...',
+  })
+  refreshToken: string;
+
+  @ApiProperty({
+    description: '토큰 타입',
+    example: 'Bearer',
+  })
+  tokenType: string;
+
+  @ApiProperty({
+    description: '토큰 만료 시간 (초)',
+    example: 3600,
+  })
+  expiresIn: number;
+
+  @ApiProperty({
+    description: '사용자 역할',
+    example: 'user',
+  })
+  role: string;
+
+  @ApiProperty({
+    description: '신규 사용자 여부',
+    example: false,
+  })
+  isNewUser: boolean;
+
+  @ApiProperty({
+    description: '본인인증 정보 (신규 사용자인 경우)',
+    required: false,
+  })
+  certificationInfo?: {
+    name: string;
+    phone: string;
+    gender: string;
+    birthday: string;
+  };
+}

--- a/src/auth/dto/signup.ts
+++ b/src/auth/dto/signup.ts
@@ -1,4 +1,4 @@
-import { IsEmail, IsNotEmpty, IsNumber, IsString, Matches, Max, MaxLength, Min, MinLength, IsOptional, ValidateNested, ArrayMaxSize } from 'class-validator';
+import { IsNotEmpty, IsNumber, IsString, IsOptional, Matches } from 'class-validator';
 import { ApiProperty } from '@nestjs/swagger';
 import { Transform } from 'class-transformer';
 import { Gender } from '@/types/enum';
@@ -6,41 +6,17 @@ import * as multer from 'multer';
 
 export class SignupRequest {
   @ApiProperty({
-    example: 'user@example.com',
-    description: '사용자 이메일',
-  })
-  @IsEmail({}, { message: '유효한 이메일 주소를 입력해주세요.' })
-  @IsNotEmpty({ message: '이메일은 필수 입력 항목입니다.' })
-  email: string;
-
-  @ApiProperty({
-    example: 'password123!',
-    description: '비밀번호 (최소 8자, 문자와 숫자, 특수문자 포함)',
-  })
-  @IsString()
-  @MinLength(8, { message: '비밀번호는 최소 8자 이상이어야 합니다.' })
-  @Matches(/^(?=.*[A-Za-z])(?=.*\d)(?=.*\W)[A-Za-z\d\W_]{8,}$/, {
-    message: '비밀번호는 최소 8자 이상이며, 문자와 숫자, 특수문자를 포함해야 합니다.',
-  })
-  password: string;
-
-  @ApiProperty({
     example: '홍길동',
     description: '사용자 이름',
   })
   @IsString()
   @IsNotEmpty({ message: '이름은 필수 입력 항목입니다.' })
-  @MaxLength(15, { message: '이름은 최대 15자까지 입력 가능합니다.' })
   name: string;
 
   @ApiProperty({
-    example: '2000-06-27',
-    description: '생년월일',
+    example: '010-1234-1234',
+    description: '전화번호',
   })
-  @IsString()
-  @IsNotEmpty({ message: '생년월일은 필수 입력 항목입니다.' })
-  birthday: string;
-
   @IsString()
   @Matches(/^010-?\d{3,4}-?\d{4}$/, {
     message: '유효한 전화번호 형식이 아닙니다.',
@@ -48,12 +24,12 @@ export class SignupRequest {
   phoneNumber: string;
 
   @ApiProperty({
-    example: 20,
-    description: '나이',
+    example: '2001-10-12',
+    description: '생년월일',
   })
-  @IsNumber()
-  @IsNotEmpty({ message: '나이는 필수 입력 항목입니다.' })
-  age: number;
+  @IsString()
+  @IsNotEmpty({ message: '생년월일은 필수 입력 항목입니다.' })
+  birthday: string;
 
   @ApiProperty({
     example: 'MALE',
@@ -67,12 +43,12 @@ export class SignupRequest {
   gender: Gender;
 
   @ApiProperty({
-    example: 'ENFJ',
-    description: 'MBTI',
+    example: 23,
+    description: '나이',
   })
-  @IsString()
-  @IsOptional()
-  mbti?: string;
+  @IsNumber()
+  @IsNotEmpty({ message: '나이는 필수 입력 항목입니다.' })
+  age: number;
 
   @ApiProperty({
     example: '서울대학교',
@@ -127,30 +103,4 @@ export class SignupRequest {
   profileImages: multer.File[];
 }
 
-export class SmsCodeCreation {
-  @ApiProperty({
-    example: '010-1234-5678',
-    description: '전화번호',
-  })
-  @IsString()
-  @Matches(/^010-?\d{3,4}-?\d{4}$/, {
-    message: '유효한 전화번호 형식이 아닙니다.',
-  })
-  phoneNumber: string;
-}
 
-export class AuthorizeSmsCode {
-  @ApiProperty({
-    example: 'sdjfdks-sdfsdfkl',
-    description: '인증 보안용 고유키',
-  })
-  @IsString()
-  uniqueKey: string;
-
-  @ApiProperty({
-    example: '123456',
-    description: '인증번호',
-  })
-  @IsString()
-  authorizationCode: string;
-}

--- a/src/auth/repository/auth.repository.ts
+++ b/src/auth/repository/auth.repository.ts
@@ -24,6 +24,15 @@ export class AuthRepository {
     return result.length > 0 ? result[0] : null;
   }
 
+  async findUserByPhoneNumber(phoneNumber: string) {
+    const result = await this.db.select()
+      .from(users)
+      .where(and(eq(users.phoneNumber, phoneNumber), isNull(users.deletedAt)))
+      .limit(1);
+
+    return result.length > 0 ? result[0] : null;
+  }
+
   async findGenderByUserId(userId: string) {
     const result = await this.db.select({
       gender: profiles.gender

--- a/src/auth/repository/signup.repository.ts
+++ b/src/auth/repository/signup.repository.ts
@@ -48,14 +48,12 @@ export class SignupRepository {
       const userId = generateUuidV7();
       const preferenceId = generateUuidV7();
 
-      const { email, password, name, age, gender, profileImages, phoneNumber, instagramId } = createUserDto;
+      const { name, phoneNumber, gender, age, instagramId } = createUserDto;
 
       const [user] = await tx.insert(users)
         .values({
           id: userId,
-          email,
           phoneNumber,
-          password,
           name,
           profileId,
           role: Role.USER,
@@ -73,13 +71,7 @@ export class SignupRepository {
         })
         .returning();
 
-      if (createUserDto.mbti) {
-        await tx.update(profiles)
-        .set({
-          mbti: createUserDto.mbti,
-        })
-        .where(eq(profiles.userId, user.id));
-      }
+
 
       await tx.insert(schema.userPreferences)
         .values({

--- a/src/auth/services/auth.service.ts
+++ b/src/auth/services/auth.service.ts
@@ -47,7 +47,7 @@ export class AuthService {
       throw new BadGatewayException('성별정보가 없습니다.');
     }
 
-    const isPasswordValid = await this.verifyPassword(password, user.password);
+    const isPasswordValid = await this.verifyPassword(password, user.password!);
     if (!isPasswordValid) {
       throw new UnauthorizedException(
         '이메일 또는 비밀번호가 올바르지 않습니다.',
@@ -56,7 +56,7 @@ export class AuthService {
 
     const tokens = await this.generateTokens(
       user.id,
-      user.email,
+      user.email || '',
       user.name,
       user.role,
       genderResult.gender,
@@ -91,7 +91,7 @@ export class AuthService {
 
       const tokens = await this.generateTokens(
         existingUser.id,
-        existingUser.email,
+        existingUser.email || '',
         existingUser.name,
         existingUser.role,
         genderResult.gender,
@@ -132,7 +132,7 @@ export class AuthService {
       throw new UnauthorizedException('사용자를 찾을 수 없습니다.');
     }
 
-    const isPasswordValid = await this.verifyPassword(password, user.password);
+    const isPasswordValid = await this.verifyPassword(password, user.password!);
     if (!isPasswordValid) {
       throw new UnauthorizedException('비밀번호가 올바르지 않습니다.');
     }
@@ -188,7 +188,7 @@ export class AuthService {
 
       const tokens = await this.generateTokens(
         user.id,
-        user.email,
+        user.email || '',
         user.name,
         user.role,
         genderResult.gender,

--- a/src/auth/services/auth.service.ts
+++ b/src/auth/services/auth.service.ts
@@ -1,4 +1,9 @@
-import { BadGatewayException, Injectable, Logger, UnauthorizedException } from '@nestjs/common';
+import {
+  BadGatewayException,
+  Injectable,
+  Logger,
+  UnauthorizedException,
+} from '@nestjs/common';
 import { JwtService } from '@nestjs/jwt';
 import { ConfigService } from '@nestjs/config';
 import * as bcrypt from 'bcryptjs';
@@ -25,33 +30,45 @@ export class AuthService {
     private readonly jwtService: JwtService,
     private readonly configService: ConfigService,
     private readonly iamportService: IamportService,
-  ) { }
+  ) {}
 
   async login(loginRequest: LoginRequest): Promise<TokenResponse> {
     const { email, password } = loginRequest;
 
     const user = await this.authRepository.findUserByEmail(email);
     if (!user) {
-      throw new UnauthorizedException('이메일 또는 비밀번호가 올바르지 않습니다.');
+      throw new UnauthorizedException(
+        '이메일 또는 비밀번호가 올바르지 않습니다.',
+      );
     }
     const genderResult = await this.authRepository.findGenderByUserId(user.id);
 
-    if (!genderResult) {  
-      throw new BadGatewayException("성별정보가 없습니다.");
+    if (!genderResult) {
+      throw new BadGatewayException('성별정보가 없습니다.');
     }
 
     const isPasswordValid = await this.verifyPassword(password, user.password);
     if (!isPasswordValid) {
-      throw new UnauthorizedException('이메일 또는 비밀번호가 올바르지 않습니다.');
+      throw new UnauthorizedException(
+        '이메일 또는 비밀번호가 올바르지 않습니다.',
+      );
     }
 
-    const tokens = await this.generateTokens(user.id, user.email, user.name, user.role, genderResult.gender);
+    const tokens = await this.generateTokens(
+      user.id,
+      user.email,
+      user.name,
+      user.role,
+      genderResult.gender,
+    );
     await this.authRepository.saveRefreshToken(user.id, tokens.refreshToken);
 
     return { ...tokens, role: user.role };
   }
 
-  async passLogin(passLoginRequest: PassLoginRequest): Promise<PassLoginResponse> {
+  async passLogin(
+    passLoginRequest: PassLoginRequest,
+  ): Promise<PassLoginResponse> {
     const { impUid } = passLoginRequest;
 
     // PortOne V2에서 본인인증 정보 조회
@@ -59,14 +76,17 @@ export class AuthService {
     const formattedPhoneNumber = this.formatPhoneNumber(certification.phone);
 
     // 전화번호로 기존 사용자 찾기
-    const existingUser = await this.authRepository.findUserByPhoneNumber(formattedPhoneNumber);
+    const existingUser =
+      await this.authRepository.findUserByPhoneNumber(formattedPhoneNumber);
 
     if (existingUser) {
       // 기존 사용자 로그인
-      const genderResult = await this.authRepository.findGenderByUserId(existingUser.id);
+      const genderResult = await this.authRepository.findGenderByUserId(
+        existingUser.id,
+      );
 
       if (!genderResult) {
-        throw new BadGatewayException("성별정보가 없습니다.");
+        throw new BadGatewayException('성별정보가 없습니다.');
       }
 
       const tokens = await this.generateTokens(
@@ -74,10 +94,13 @@ export class AuthService {
         existingUser.email,
         existingUser.name,
         existingUser.role,
-        genderResult.gender
+        genderResult.gender,
       );
 
-      await this.authRepository.saveRefreshToken(existingUser.id, tokens.refreshToken);
+      await this.authRepository.saveRefreshToken(
+        existingUser.id,
+        tokens.refreshToken,
+      );
 
       return {
         ...tokens,
@@ -120,7 +143,9 @@ export class AuthService {
   async refreshToken(refreshToken: string): Promise<TokenResponse> {
     try {
       this.logger.log(`리프레시 토큰 검증, 토큰 길이: ${refreshToken?.length}`);
-      this.logger.log(`JWT_SECRET: ${this.configService.get<string>('JWT_SECRET')?.substring(0, 3)}...`);
+      this.logger.log(
+        `JWT_SECRET: ${this.configService.get<string>('JWT_SECRET')?.substring(0, 3)}...`,
+      );
 
       // 토큰 디코딩 시도 (검증 없이)
       try {
@@ -130,15 +155,21 @@ export class AuthService {
         this.logger.error(`토큰 디코딩 실패: ${decodeError.message}`);
       }
 
-      const payload = await this.jwtService.verifyAsync<JwtPayload>(refreshToken, {
-        secret: this.configService.get<string>('JWT_SECRET'),
-      });
+      const payload = await this.jwtService.verifyAsync<JwtPayload>(
+        refreshToken,
+        {
+          secret: this.configService.get<string>('JWT_SECRET'),
+        },
+      );
 
       this.logger.log(`토큰 검증 성공, payload: ${JSON.stringify(payload)}`);
 
-      const storedToken = await this.authRepository.findRefreshToken(payload.id, refreshToken);
+      const storedToken = await this.authRepository.findRefreshToken(
+        payload.id,
+        refreshToken,
+      );
       if (!storedToken) {
-        this.logger.log("저장된 리프레시토큰이 없음");
+        this.logger.log('저장된 리프레시토큰이 없음');
         throw new UnauthorizedException('유효하지 않은 리프레시 토큰입니다.');
       }
 
@@ -147,18 +178,30 @@ export class AuthService {
         throw new UnauthorizedException('사용자를 찾을 수 없습니다.');
       }
 
-      const genderResult = await this.authRepository.findGenderByUserId(user.id);
+      const genderResult = await this.authRepository.findGenderByUserId(
+        user.id,
+      );
 
       if (!genderResult) {
-        throw new BadGatewayException("성별정보가 없습니다.");
+        throw new BadGatewayException('성별정보가 없습니다.');
       }
 
-      const tokens = await this.generateTokens(user.id, user.email, user.name, user.role, genderResult.gender);
-      await this.authRepository.updateRefreshToken(user.id, refreshToken, tokens.refreshToken);
+      const tokens = await this.generateTokens(
+        user.id,
+        user.email,
+        user.name,
+        user.role,
+        genderResult.gender,
+      );
+      await this.authRepository.updateRefreshToken(
+        user.id,
+        refreshToken,
+        tokens.refreshToken,
+      );
 
       return tokens;
     } catch (error) {
-      this.logger.error("리프레시 토큰 검증 실패");
+      this.logger.error('리프레시 토큰 검증 실패');
       this.logger.error(`오류 타입: ${error.name}, 메시지: ${error.message}`);
       this.logger.error(`오류 상세: ${JSON.stringify(error)}`);
 
@@ -182,7 +225,10 @@ export class AuthService {
     await this.authRepository.removeRefreshToken(userId, refreshToken);
   }
 
-  private async verifyPassword(plainPassword: string, hashedPassword: string): Promise<boolean> {
+  private async verifyPassword(
+    plainPassword: string,
+    hashedPassword: string,
+  ): Promise<boolean> {
     return bcrypt.compare(plainPassword, hashedPassword);
   }
 
@@ -204,8 +250,16 @@ export class AuthService {
     return phoneNumber;
   }
 
-  private async generateTokens(userId: string, email: string, name: string, role: Role, gender: Gender): Promise<TokenResponse> {
-    this.logger.log(`토큰 생성 시작 - userId: ${userId}, email: ${email}, name: ${name}, role: ${role}, gender: ${gender}`);
+  private async generateTokens(
+    userId: string,
+    email: string,
+    name: string,
+    role: Role,
+    gender: Gender,
+  ): Promise<TokenResponse> {
+    this.logger.log(
+      `토큰 생성 시작 - userId: ${userId}, email: ${email}, name: ${name}, role: ${role}, gender: ${gender}`,
+    );
 
     const accessToken = await this.jwtService.signAsync(
       { id: userId, email, name, role, gender },
@@ -225,8 +279,9 @@ export class AuthService {
 
     try {
       const decoded = this.jwtService.decode(refreshToken);
-      this.logger.log(`생성된 리프레시 토큰 디코딩: ${JSON.stringify(decoded)}`);
-
+      this.logger.log(
+        `생성된 리프레시 토큰 디코딩: ${JSON.stringify(decoded)}`,
+      );
     } catch (error) {
       this.logger.error(`생성된 토큰 디코딩 실패: ${error.message}`);
     }

--- a/src/auth/services/iamport.service.ts
+++ b/src/auth/services/iamport.service.ts
@@ -43,7 +43,7 @@ export class IamportService {
 
   constructor(private readonly configService: ConfigService) {
     this.impKey = this.configService.get<string>('PORTONE_REST_API_KEY') || '';
-    this.impSecret = this.configService.get<string>('PORTONE_SECRET_KEY') || '';
+    this.impSecret = this.configService.get<string>('PORTONE_V2_SECRET_KEY') || '';
 
     this.httpClient = axios.create({
       baseURL: 'https://api.portone.io',

--- a/src/auth/services/iamport.service.ts
+++ b/src/auth/services/iamport.service.ts
@@ -1,0 +1,120 @@
+import { Injectable, Logger, BadRequestException, UnauthorizedException } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import axios, { AxiosInstance } from 'axios';
+
+interface IamportTokenResponse {
+  code: number;
+  message: string;
+  response: {
+    access_token: string;
+    expired_at: number;
+    now: number;
+  };
+}
+
+interface IamportCertificationResponse {
+  code: number;
+  message: string;
+  response: {
+    imp_uid: string;
+    merchant_uid: string;
+    pg_tid: string;
+    pg_provider: string;
+    name: string;
+    gender: string;
+    birthday: string;
+    foreigner: boolean;
+    phone: string;
+    carrier: string;
+    certified: boolean;
+    certified_at: number;
+    unique_key: string;
+    unique_in_site: string;
+    origin: string;
+  };
+}
+
+@Injectable()
+export class IamportService {
+  private readonly logger = new Logger(IamportService.name);
+  private readonly httpClient: AxiosInstance;
+  private readonly impKey: string;
+  private readonly impSecret: string;
+
+  constructor(private readonly configService: ConfigService) {
+    this.impKey = this.configService.get<string>('PORTONE_REST_API_KEY') || '';
+    this.impSecret = this.configService.get<string>('PORTONE_SECRET_KEY') || '';
+
+    this.httpClient = axios.create({
+      baseURL: 'https://api.portone.io',
+      timeout: 10000,
+    });
+
+    if (!this.impKey || !this.impSecret) {
+      this.logger.error('PortOne API 키가 설정되지 않았습니다.');
+      throw new Error('PortOne API 키가 설정되지 않았습니다.');
+    }
+  }
+
+  /**
+   * PortOne V2 액세스 토큰 발급
+   */
+  private async getAccessToken(): Promise<string> {
+    try {
+      const response = await this.httpClient.post('/login/api-secret', {
+        apiSecret: this.impSecret,
+      });
+
+      if (!response.data.accessToken) {
+        throw new BadRequestException('PortOne 토큰 발급 실패');
+      }
+
+      return response.data.accessToken;
+    } catch (error) {
+      this.logger.error('PortOne 토큰 발급 실패:', error);
+      throw new BadRequestException('PortOne 토큰 발급에 실패했습니다.');
+    }
+  }
+
+  /**
+   * PortOne V2 본인인증 정보 조회
+   * @param identityVerificationId PortOne 본인인증 고유번호
+   */
+  async getCertification(identityVerificationId: string): Promise<any> {
+    try {
+      const accessToken = await this.getAccessToken();
+
+      const response = await this.httpClient.get(
+        `/identity-verifications/${identityVerificationId}`,
+        {
+          headers: {
+            Authorization: `Bearer ${accessToken}`,
+          },
+        }
+      );
+
+      const verification = response.data;
+
+      // 본인인증이 완료되지 않은 경우
+      if (verification.status !== 'VERIFIED') {
+        throw new UnauthorizedException('본인인증이 완료되지 않았습니다.');
+      }
+
+      this.logger.log(`본인인증 정보 조회 성공: ${verification.verifiedCustomer?.name} (${verification.verifiedCustomer?.phoneNumber})`);
+
+      return {
+        name: verification.verifiedCustomer?.name,
+        phone: verification.verifiedCustomer?.phoneNumber,
+        gender: verification.verifiedCustomer?.gender,
+        birthday: verification.verifiedCustomer?.birthDate,
+        certified: true,
+      };
+    } catch (error) {
+      this.logger.error('본인인증 정보 조회 실패:', error);
+      if (error instanceof BadRequestException || error instanceof UnauthorizedException) {
+        throw error;
+      }
+      throw new BadRequestException('본인인증 정보 조회에 실패했습니다.');
+    }
+  }
+}

--- a/src/database/schema/profiles.ts
+++ b/src/database/schema/profiles.ts
@@ -24,5 +24,6 @@ export const profiles = pgTable('profiles', {
   introduction: varchar('introduction', { length: 255 }),
   rank: varchar('rank', { length: 7, enum: ['S', 'A', 'B', 'C', 'UNKNOWN'] }).default('UNKNOWN').notNull(),
   universityDetailId: varchar('university_detail_id', { length: 36 }),
+  statusAt: varchar('status_at', { length: 16 }),
   ...timestamps,
 });

--- a/src/database/schema/users.ts
+++ b/src/database/schema/users.ts
@@ -5,8 +5,8 @@ import { Role } from '@/auth/domain/user-role.enum';
 export const users = pgTable('users', {
   id: uuid(),
   name: varchar('name', { length: 15 }).notNull(),
-  email: varchar('email', { length: 100 }).notNull(),
-  password: varchar('password', { length: 100 }).notNull(),
+  email: varchar('email', { length: 100 }),
+  password: varchar('password', { length: 100 }),
   phoneNumber: varchar('phone_number', { length: 16 }).notNull(),
   profileId: varchar('profile_id', { length: 36 }),
   oauthProvider: varchar('oauth_provider', { length: 30 }),

--- a/src/main.ts
+++ b/src/main.ts
@@ -38,8 +38,9 @@ async function bootstrap() {
 
   app.enableCors({
     origin: [
+      'http://10.0.2.2:3000',
       'http://localhost:3000',
-      'http://172.20.196.148:3000',
+      'http://192.168.1.100:3000',
       'http://localhost:3001',
       'http://localhost:8000',  // Community Bot API 포트 추가
       'https://project-solo-gray.vercel.app',

--- a/src/matching/services/matching-alert-cron.service.ts
+++ b/src/matching/services/matching-alert-cron.service.ts
@@ -25,12 +25,14 @@ export class MatchingAlertCronService {
       return;
     }
 
-    const tasks = users.map(user =>
-      limit(() =>
-        this.mailService.sendMatchingAlertEmail(user.email, user.name)
-          .catch(e => this.logger.error(`Failed to send to ${user.email}: ${e.message}`))
-      )
-    );
+    const tasks = users
+      .filter(user => user.email) // email이 있는 사용자만 필터링
+      .map(user =>
+        limit(() =>
+          this.mailService.sendMatchingAlertEmail(user.email!, user.name)
+            .catch(e => this.logger.error(`Failed to send to ${user.email}: ${e.message}`))
+        )
+      );
 
     await this.cacheManager.set('mailBatchStatus', true, 1000 * 60 * 60 * 3);
 

--- a/src/payment/services/pay.service.ts
+++ b/src/payment/services/pay.service.ts
@@ -1,17 +1,31 @@
-import { Injectable, HttpException, HttpStatus, BadGatewayException, Logger, UnauthorizedException, BadRequestException } from "@nestjs/common";
-import { ConfigService } from "@nestjs/config";
-import { PaymentConfirm } from "../dto";
-import { PayBeforeHistory, PaymentDetails, PortOneCustomData, PortOnePaymentV2, Product } from "@/types/payment";
-import { PortoneWebhookDto, PortonePaymentStatus } from "../dto/webhook.dto";
-import PayRepository from "../repository/pay.repository";
+import {
+  Injectable,
+  HttpException,
+  HttpStatus,
+  BadGatewayException,
+  Logger,
+  UnauthorizedException,
+  BadRequestException,
+} from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { PaymentConfirm } from '../dto';
+import {
+  PayBeforeHistory,
+  PaymentDetails,
+  PortOneCustomData,
+  PortOnePaymentV2,
+  Product,
+} from '@/types/payment';
+import { PortoneWebhookDto, PortonePaymentStatus } from '../dto/webhook.dto';
+import PayRepository from '../repository/pay.repository';
 import { Payment, PortOneClient } from '@portone/server-sdk';
-import { TicketService } from "./ticket.service";
-import { axiosHandler } from "@/common/helper";
+import { TicketService } from './ticket.service';
+import { axiosHandler } from '@/common/helper';
 import { createHmac } from 'crypto';
-import axios from "axios";
-import { SlackService } from "@/slack-notification/slack.service";
-import UserRepository from "@/user/repository/user.repository";
-import weekDateService from "@/matching/domain/date";
+import axios from 'axios';
+import { SlackService } from '@/slack-notification/slack.service';
+import UserRepository from '@/user/repository/user.repository';
+import weekDateService from '@/matching/domain/date';
 
 @Injectable()
 export default class PayService {
@@ -27,7 +41,7 @@ export default class PayService {
     private readonly slackService: SlackService,
     private readonly userRepository: UserRepository,
   ) {
-    const secretKey = configService.get('PORTONE_V2_SECRET_KEY') as string;
+    const secretKey = configService.get('PORTONE_SECRET_KEY') as string;
     this.client = PortOneClient({ secret: secretKey });
     this.secretKey = secretKey;
     this.storeId = configService.get('PORTONE_STORE_ID') as string;
@@ -47,7 +61,9 @@ export default class PayService {
     }
 
     try {
-      const { response: portOnePayment } = await this.getPayment(merchantUid) as { response: PaymentDetails };
+      const { response: portOnePayment } = (await this.getPayment(
+        merchantUid,
+      )) as { response: PaymentDetails };
       this.logger.debug(portOnePayment);
 
       if (['paid', 'PAID'].includes(portOnePayment.status)) {
@@ -63,7 +79,7 @@ export default class PayService {
           history.orderName,
           history.amount,
           portOnePayment.emb_pg_provider || '알 수 없음',
-          new Date(portOnePayment.paid_at)
+          new Date(portOnePayment.paid_at),
         );
       }
     } catch (error) {
@@ -79,7 +95,7 @@ export default class PayService {
     orderName: string,
     amount: number,
     method: string,
-    paidAt: Date
+    paidAt: Date,
   ) {
     try {
       const user = await this.userRepository.getUser(userId);
@@ -91,7 +107,7 @@ export default class PayService {
         orderName,
         amount,
         method,
-        paidAt
+        paidAt,
       );
       return true;
     } catch (error) {
@@ -115,7 +131,7 @@ export default class PayService {
         return { success: false, message: '결제 내역을 찾을 수 없음' };
       }
 
-      const payment = await this.getPayment(payment_id) as PortOnePaymentV2;
+      const payment = (await this.getPayment(payment_id)) as PortOnePaymentV2;
 
       this.logger.debug('결제 내역 조회');
       this.logger.debug(payment);
@@ -133,7 +149,11 @@ export default class PayService {
         txId: payment.pgTxId,
       });
 
-      await this.strategy(history.userId, payment.orderName as Product, customData);
+      await this.strategy(
+        history.userId,
+        payment.orderName as Product,
+        customData,
+      );
 
       const notificationSent = await this.sendPaymentSlackNotification(
         history.userId,
@@ -145,7 +165,7 @@ export default class PayService {
 
       return {
         success: true,
-        notificationSent
+        notificationSent,
       };
     } catch (error) {
       this.logger.error(`결제 웹훅 처리 중 오류 발생: `);
@@ -154,9 +174,16 @@ export default class PayService {
     }
   }
 
-  private strategy(userId: string, product: Product, customData: PortOneCustomData) {
+  private strategy(
+    userId: string,
+    product: Product,
+    customData: PortOneCustomData,
+  ) {
     if (product === Product.REMATCHING) {
-      return this.ticketService.createRematchingTickets(userId, customData.productCount);
+      return this.ticketService.createRematchingTickets(
+        userId,
+        customData.productCount,
+      );
     }
   }
   private async getPayment(paymentId: string) {

--- a/src/slack-notification/slack.service.ts
+++ b/src/slack-notification/slack.service.ts
@@ -313,11 +313,11 @@ export class SlackService {
         fields: [
           {
             type: "mrkdwn",
-            text: "*이메일:*\n" + signupData.email
+            text: "*전화번호:*\n" + signupData.phoneNumber
           },
           {
             type: "mrkdwn",
-            text: "*전화번호:*\n" + signupData.phoneNumber
+            text: "*이름:*\n" + signupData.name
           }
         ]
       },
@@ -362,22 +362,16 @@ export class SlackService {
       }
     ];
 
-    // MBTI가 있는 경우 추가
-    if (signupData.mbti) {
-      blocks.push({
-        type: "section",
-        fields: [
-          {
-            type: "mrkdwn",
-            text: "*MBTI:*\n" + signupData.mbti
-          },
-          {
-            type: "mrkdwn",
-            text: "*인스타그램:*\n" + (signupData.instagramId || "없음")
-          }
-        ]
-      });
-    }
+    // 인스타그램 정보 추가
+    blocks.push({
+      type: "section",
+      fields: [
+        {
+          type: "mrkdwn",
+          text: "*인스타그램:*\n" + (signupData.instagramId || "없음")
+        }
+      ]
+    });
 
     // 프로필 이미지 수 추가
     if (signupData.profileImages && signupData.profileImages.length > 0) {

--- a/src/user/services/user.service.ts
+++ b/src/user/services/user.service.ts
@@ -13,6 +13,11 @@ export default class UserService {
 
   async updatePassword(userId: string, data: PasswordUpdated) {
     const user = await this.userRepository.getUser(userId);
+
+    if (!user.password) {
+      throw new BadRequestException('Pass 인증 사용자는 비밀번호 변경이 불가능합니다.');
+    }
+
     const isPasswordCorrect = await bcrypt.compare(data.oldPassword, user.password);
     if (!isPasswordCorrect) {
       throw new BadRequestException('비밀번호가 일치하지 않습니다.');
@@ -54,7 +59,7 @@ export default class UserService {
     return {
       id: userRaw.id,
       age: profile.age,
-      email: userRaw.email,
+      email: userRaw.email || '',
       gender: profile.gender,
       name: userRaw.name,
       phoneNumber: userRaw.phoneNumber,


### PR DESCRIPTION
# 요약
PASS 본인인증을 활용하여 회원가입 프로세스를 대폭 간소화하고 사용자 경험을 개선했습니다. 기존 7단계의 회원가입 절차를 4단계로 축소했으며, PASS 인증을 통해 받은 정보를 회원가입 폼에 직접 활용하도록 백엔드 로직을 변경했습니다.

# 주요 변경사항
1. PASS 본인인증 통합에 따른 백엔드 로직 변경
프런트엔드에서 PASS 본인인증을 통해 받은 사용자 정보를 백엔드 회원가입 로직에 직접 연동했습니다.

2. PASS 가입자 처리: PASS 인증으로 가입하는 사용자의 경우, 이메일과 비밀번호를 별도로 받지 않으므로 관련 유효성 검사 및 저장 로직을 조정했습니다.

3. 메일러 서비스 비활성화: PASS 가입자는 이메일을 통해 계정 정보를 받지 않으므로, 이메일/비밀번호 기반 회원가입 시 사용되던 메일러 서비스(예: 이메일 인증, 비밀번호 초기화 메일 발송 등)가 작동하지 않도록 임시로 막아두었습니다. 향후 메일러 서비스의 기능 재정의 및 확장이 필요할 수 있습니다.

4. 프런트엔드 정보 활용: 프런트엔드로부터 받은 PASS 인증 기반 정보를 바탕으로 회원가입이 완료되도록 데이터 처리 로직을 구현했습니다.