### PR TITLE
feat: 본인 성향 분리 및 API 문서 개선

### DIFF
--- a/drizzle/0014_organic_spitfire.sql
+++ b/drizzle/0014_organic_spitfire.sql
@@ -1,0 +1,12 @@
+CREATE TABLE "additional_preferences" (
+	"id" varchar(128) PRIMARY KEY NOT NULL,
+	"good_mbti" varchar(4),
+	"bad_mbti" varchar(4),
+	"profile_id" varchar NOT NULL,
+	"updated_at" timestamp with time zone,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"deleted_at" timestamp with time zone,
+	CONSTRAINT "additional_preferences_profile_id_unique" UNIQUE("profile_id")
+);
+
+ALTER TABLE "additional_preferences" ADD CONSTRAINT "additional_preferences_profile_id_profiles_id_fk" FOREIGN KEY ("profile_id") REFERENCES "public"."profiles"("id") ON DELETE no action ON UPDATE no action;

--- a/drizzle/meta/0014_snapshot.json
+++ b/drizzle/meta/0014_snapshot.json
@@ -1,0 +1,1968 @@
+{
+  "id": "54af47f6-95e4-4624-ae41-420d91e1da98",
+  "prevId": "f3ed26e7-23f4-4cf3-af43-bf05e2049a38",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.additional_preferences": {
+      "name": "additional_preferences",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(128)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "good_mbti": {
+          "name": "good_mbti",
+          "type": "varchar(4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bad_mbti": {
+          "name": "bad_mbti",
+          "type": "varchar(4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "profile_id": {
+          "name": "profile_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "additional_preferences_profile_id_profiles_id_fk": {
+          "name": "additional_preferences_profile_id_profiles_id_fk",
+          "tableFrom": "additional_preferences",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "additional_preferences_profile_id_unique": {
+          "name": "additional_preferences_profile_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "profile_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.article_categories": {
+      "name": "article_categories",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(128)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "emoji_url": {
+          "name": "emoji_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code": {
+          "name": "code",
+          "type": "varchar(15)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.articles": {
+      "name": "articles",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(128)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(30)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category_id": {
+          "name": "category_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "anonymous": {
+          "name": "anonymous",
+          "type": "varchar(15)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "like_count": {
+          "name": "like_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "blinded_at": {
+          "name": "blinded_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "read_count": {
+          "name": "read_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "articles_author_id_users_id_fk": {
+          "name": "articles_author_id_users_id_fk",
+          "tableFrom": "articles",
+          "tableTo": "users",
+          "columnsFrom": [
+            "author_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "articles_category_id_article_categories_id_fk": {
+          "name": "articles_category_id_article_categories_id_fk",
+          "tableFrom": "articles",
+          "tableTo": "article_categories",
+          "columnsFrom": [
+            "category_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.comments": {
+      "name": "comments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(128)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "article_id": {
+          "name": "article_id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content": {
+          "name": "content",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "nickname": {
+          "name": "nickname",
+          "type": "varchar(15)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "blinded_at": {
+          "name": "blinded_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "comments_author_id_users_id_fk": {
+          "name": "comments_author_id_users_id_fk",
+          "tableFrom": "comments",
+          "tableTo": "users",
+          "columnsFrom": [
+            "author_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "comments_article_id_articles_id_fk": {
+          "name": "comments_article_id_articles_id_fk",
+          "tableFrom": "comments",
+          "tableTo": "articles",
+          "columnsFrom": [
+            "article_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "comments_parent_id_comments_id_fk": {
+          "name": "comments_parent_id_comments_id_fk",
+          "tableFrom": "comments",
+          "tableTo": "comments",
+          "columnsFrom": [
+            "parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.hot_articles": {
+      "name": "hot_articles",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(128)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "article_id": {
+          "name": "article_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "curator_comment": {
+          "name": "curator_comment",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "hot_articles_article_id_articles_id_fk": {
+          "name": "hot_articles_article_id_articles_id_fk",
+          "tableFrom": "hot_articles",
+          "tableTo": "articles",
+          "columnsFrom": [
+            "article_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.images": {
+      "name": "images",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(128)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "s3_url": {
+          "name": "s3_url",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "s3_key": {
+          "name": "s3_key",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "original_filename": {
+          "name": "original_filename",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mime_type": {
+          "name": "mime_type",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "size_in_bytes": {
+          "name": "size_in_bytes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_verified": {
+          "name": "is_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.likes": {
+      "name": "likes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(128)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "article_id": {
+          "name": "article_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "up": {
+          "name": "up",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "likes_user_id_users_id_fk": {
+          "name": "likes_user_id_users_id_fk",
+          "tableFrom": "likes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "likes_article_id_articles_id_fk": {
+          "name": "likes_article_id_articles_id_fk",
+          "tableFrom": "likes",
+          "tableTo": "articles",
+          "columnsFrom": [
+            "article_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.matches": {
+      "name": "matches",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(128)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "my_id": {
+          "name": "my_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "matcher_id": {
+          "name": "matcher_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "score": {
+          "name": "score",
+          "type": "numeric(8, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "direct": {
+          "name": "direct",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "published_at": {
+          "name": "published_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expired_at": {
+          "name": "expired_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(30)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "matches_my_id_users_id_fk": {
+          "name": "matches_my_id_users_id_fk",
+          "tableFrom": "matches",
+          "tableTo": "users",
+          "columnsFrom": [
+            "my_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "matches_matcher_id_users_id_fk": {
+          "name": "matches_matcher_id_users_id_fk",
+          "tableFrom": "matches",
+          "tableTo": "users",
+          "columnsFrom": [
+            "matcher_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.matching_failure_logs": {
+      "name": "matching_failure_logs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(128)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "matching_failure_logs_user_id_users_id_fk": {
+          "name": "matching_failure_logs_user_id_users_id_fk",
+          "tableFrom": "matching_failure_logs",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.matching_requests": {
+      "name": "matching_requests",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(128)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "score": {
+          "name": "score",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pay_histories": {
+      "name": "pay_histories",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(128)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "amount": {
+          "name": "amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "method": {
+          "name": "method",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "order_id": {
+          "name": "order_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "order_name": {
+          "name": "order_name",
+          "type": "varchar(30)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tx_id": {
+          "name": "tx_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payment_key": {
+          "name": "payment_key",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "receipt_url": {
+          "name": "receipt_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "paid_at": {
+          "name": "paid_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "pay_histories_user_id_users_id_fk": {
+          "name": "pay_histories_user_id_users_id_fk",
+          "tableFrom": "pay_histories",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.preference_options": {
+      "name": "preference_options",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(128)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "preference_type_id": {
+          "name": "preference_type_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "value": {
+          "name": "value",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.preference_types": {
+      "name": "preference_types",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(128)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "code": {
+          "name": "code",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "multi_select": {
+          "name": "multi_select",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "maximum_choice_count": {
+          "name": "maximum_choice_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "preference_types_code_unique": {
+          "name": "preference_types_code_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "code"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.profile_images": {
+      "name": "profile_images",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(128)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "profile_id": {
+          "name": "profile_id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "image_id": {
+          "name": "image_id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "image_order": {
+          "name": "image_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_main": {
+          "name": "is_main",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "profile_images_profile_id_profiles_id_fk": {
+          "name": "profile_images_profile_id_profiles_id_fk",
+          "tableFrom": "profile_images",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "profile_images_image_id_images_id_fk": {
+          "name": "profile_images_image_id_images_id_fk",
+          "tableFrom": "profile_images",
+          "tableTo": "images",
+          "columnsFrom": [
+            "image_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.profiles": {
+      "name": "profiles",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(128)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "age": {
+          "name": "age",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "gender": {
+          "name": "gender",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(15)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mbti": {
+          "name": "mbti",
+          "type": "varchar(4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "instagram_id": {
+          "name": "instagram_id",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_matching_enable": {
+          "name": "is_matching_enable",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "introduction": {
+          "name": "introduction",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rank": {
+          "name": "rank",
+          "type": "varchar(7)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'UNKNOWN'"
+        },
+        "university_detail_id": {
+          "name": "university_detail_id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "profiles_user_id_users_id_fk": {
+          "name": "profiles_user_id_users_id_fk",
+          "tableFrom": "profiles",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "profiles_user_id_unique": {
+          "name": "profiles_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.reports": {
+      "name": "reports",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(128)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "post_id": {
+          "name": "post_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reporter_id": {
+          "name": "reporter_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reported_id": {
+          "name": "reported_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(15)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "reports_post_id_articles_id_fk": {
+          "name": "reports_post_id_articles_id_fk",
+          "tableFrom": "reports",
+          "tableTo": "articles",
+          "columnsFrom": [
+            "post_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "reports_reporter_id_users_id_fk": {
+          "name": "reports_reporter_id_users_id_fk",
+          "tableFrom": "reports",
+          "tableTo": "users",
+          "columnsFrom": [
+            "reporter_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "reports_reported_id_users_id_fk": {
+          "name": "reports_reported_id_users_id_fk",
+          "tableFrom": "reports",
+          "tableTo": "users",
+          "columnsFrom": [
+            "reported_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sms_authorization": {
+      "name": "sms_authorization",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(128)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "phone_number": {
+          "name": "phone_number",
+          "type": "varchar(15)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "unique_key": {
+          "name": "unique_key",
+          "type": "varchar(62)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "authorization_code": {
+          "name": "authorization_code",
+          "type": "varchar(12)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_authorized": {
+          "name": "is_authorized",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tickets": {
+      "name": "tickets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(128)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(30)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "used_at": {
+          "name": "used_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expired_at": {
+          "name": "expired_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "tickets_user_id_users_id_fk": {
+          "name": "tickets_user_id_users_id_fk",
+          "tableFrom": "tickets",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.university_details": {
+      "name": "university_details",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(128)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "university_name": {
+          "name": "university_name",
+          "type": "varchar(30)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "department": {
+          "name": "department",
+          "type": "varchar(30)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "authentication": {
+          "name": "authentication",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "grade": {
+          "name": "grade",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "student_number": {
+          "name": "student_number",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "university_details_user_id_users_id_fk": {
+          "name": "university_details_user_id_users_id_fk",
+          "tableFrom": "university_details",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_preference_options": {
+      "name": "user_preference_options",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(128)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_preference_id": {
+          "name": "user_preference_id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "preference_option_id": {
+          "name": "preference_option_id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "preference_target": {
+          "name": "preference_target",
+          "type": "preference_target",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'PARTNER'"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_preferences": {
+      "name": "user_preferences",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(128)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "distance_max": {
+          "name": "distance_max",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_preferences_user_id_users_id_fk": {
+          "name": "user_preferences_user_id_users_id_fk",
+          "tableFrom": "user_preferences",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_preferences_user_id_unique": {
+          "name": "user_preferences_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_range_preferences": {
+      "name": "user_range_preferences",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(128)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_preference_id": {
+          "name": "user_preference_id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "preference_type_id": {
+          "name": "preference_type_id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "min_value": {
+          "name": "min_value",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "max_value": {
+          "name": "max_value",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(128)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(15)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "password": {
+          "name": "password",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "phone_number": {
+          "name": "phone_number",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "profile_id": {
+          "name": "profile_id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "oauth_provider": {
+          "name": "oauth_provider",
+          "type": "varchar(30)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "suspended_at": {
+          "name": "suspended_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'user'"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.withdrawal_reasons": {
+      "name": "withdrawal_reasons",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(128)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -99,6 +99,13 @@
       "when": 1751516343859,
       "tag": "0013_small_greymalkin",
       "breakpoints": false
+    },
+    {
+      "idx": 14,
+      "version": "7",
+      "when": 1751610192430,
+      "tag": "0014_organic_spitfire",
+      "breakpoints": false
     }
   ]
 }

--- a/drizzle/relations.ts
+++ b/drizzle/relations.ts
@@ -1,27 +1,37 @@
 import { relations } from "drizzle-orm/relations";
-import { users, articles, matches, profiles, comments, likes, payHistories, reports, universityDetails, userPreferences, tickets, profileImages, images } from "./schema";
+import { users, comments, articles, likes, matchingFailureLogs, hotArticles, profiles, matches, additionalPreferences, articleCategories, payHistories, reports, tickets, universityDetails, userPreferences, profileImages, images } from "./schema";
 
-export const articlesRelations = relations(articles, ({one, many}) => ({
+export const commentsRelations = relations(comments, ({one, many}) => ({
 	user: one(users, {
-		fields: [articles.authorId],
+		fields: [comments.authorId],
 		references: [users.id]
 	}),
-	comments: many(comments),
-	likes: many(likes),
-	reports: many(reports),
+	comment: one(comments, {
+		fields: [comments.parentId],
+		references: [comments.id],
+		relationName: "comments_parentId_comments_id"
+	}),
+	comments: many(comments, {
+		relationName: "comments_parentId_comments_id"
+	}),
+	article: one(articles, {
+		fields: [comments.articleId],
+		references: [articles.id]
+	}),
 }));
 
 export const usersRelations = relations(users, ({many}) => ({
-	articles: many(articles),
+	comments: many(comments),
+	likes: many(likes),
+	matchingFailureLogs: many(matchingFailureLogs),
+	profiles: many(profiles),
 	matches_myId: many(matches, {
 		relationName: "matches_myId_users_id"
 	}),
 	matches_matcherId: many(matches, {
 		relationName: "matches_matcherId_users_id"
 	}),
-	profiles: many(profiles),
-	comments: many(comments),
-	likes: many(likes),
+	articles: many(articles),
 	payHistories: many(payHistories),
 	reports_reporterId: many(reports, {
 		relationName: "reports_reporterId_users_id"
@@ -29,9 +39,58 @@ export const usersRelations = relations(users, ({many}) => ({
 	reports_reportedId: many(reports, {
 		relationName: "reports_reportedId_users_id"
 	}),
+	tickets: many(tickets),
 	universityDetails: many(universityDetails),
 	userPreferences: many(userPreferences),
-	tickets: many(tickets),
+}));
+
+export const articlesRelations = relations(articles, ({one, many}) => ({
+	comments: many(comments),
+	likes: many(likes),
+	hotArticles: many(hotArticles),
+	user: one(users, {
+		fields: [articles.authorId],
+		references: [users.id]
+	}),
+	articleCategory: one(articleCategories, {
+		fields: [articles.categoryId],
+		references: [articleCategories.id]
+	}),
+	reports: many(reports),
+}));
+
+export const likesRelations = relations(likes, ({one}) => ({
+	user: one(users, {
+		fields: [likes.userId],
+		references: [users.id]
+	}),
+	article: one(articles, {
+		fields: [likes.articleId],
+		references: [articles.id]
+	}),
+}));
+
+export const matchingFailureLogsRelations = relations(matchingFailureLogs, ({one}) => ({
+	user: one(users, {
+		fields: [matchingFailureLogs.userId],
+		references: [users.id]
+	}),
+}));
+
+export const hotArticlesRelations = relations(hotArticles, ({one}) => ({
+	article: one(articles, {
+		fields: [hotArticles.articleId],
+		references: [articles.id]
+	}),
+}));
+
+export const profilesRelations = relations(profiles, ({one, many}) => ({
+	user: one(users, {
+		fields: [profiles.userId],
+		references: [users.id]
+	}),
+	additionalPreferences: many(additionalPreferences),
+	profileImages: many(profileImages),
 }));
 
 export const matchesRelations = relations(matches, ({one}) => ({
@@ -47,34 +106,15 @@ export const matchesRelations = relations(matches, ({one}) => ({
 	}),
 }));
 
-export const profilesRelations = relations(profiles, ({one, many}) => ({
-	user: one(users, {
-		fields: [profiles.userId],
-		references: [users.id]
-	}),
-	profileImages: many(profileImages),
-}));
-
-export const commentsRelations = relations(comments, ({one}) => ({
-	user: one(users, {
-		fields: [comments.authorId],
-		references: [users.id]
-	}),
-	article: one(articles, {
-		fields: [comments.postId],
-		references: [articles.id]
+export const additionalPreferencesRelations = relations(additionalPreferences, ({one}) => ({
+	profile: one(profiles, {
+		fields: [additionalPreferences.profileId],
+		references: [profiles.id]
 	}),
 }));
 
-export const likesRelations = relations(likes, ({one}) => ({
-	user: one(users, {
-		fields: [likes.userId],
-		references: [users.id]
-	}),
-	article: one(articles, {
-		fields: [likes.articleId],
-		references: [articles.id]
-	}),
+export const articleCategoriesRelations = relations(articleCategories, ({many}) => ({
+	articles: many(articles),
 }));
 
 export const payHistoriesRelations = relations(payHistories, ({one}) => ({
@@ -101,6 +141,13 @@ export const reportsRelations = relations(reports, ({one}) => ({
 	}),
 }));
 
+export const ticketsRelations = relations(tickets, ({one}) => ({
+	user: one(users, {
+		fields: [tickets.userId],
+		references: [users.id]
+	}),
+}));
+
 export const universityDetailsRelations = relations(universityDetails, ({one}) => ({
 	user: one(users, {
 		fields: [universityDetails.userId],
@@ -111,13 +158,6 @@ export const universityDetailsRelations = relations(universityDetails, ({one}) =
 export const userPreferencesRelations = relations(userPreferences, ({one}) => ({
 	user: one(users, {
 		fields: [userPreferences.userId],
-		references: [users.id]
-	}),
-}));
-
-export const ticketsRelations = relations(tickets, ({one}) => ({
-	user: one(users, {
-		fields: [tickets.userId],
 		references: [users.id]
 	}),
 }));

--- a/drizzle/schema.ts
+++ b/drizzle/schema.ts
@@ -1,26 +1,27 @@
-import { pgTable, varchar, timestamp, text, unique, boolean, integer, foreignKey, numeric } from "drizzle-orm/pg-core"
+import { pgTable, varchar, timestamp, text, unique, boolean, integer, foreignKey, numeric, pgEnum } from "drizzle-orm/pg-core"
 import { sql } from "drizzle-orm"
 
+export const preferenceTarget = pgEnum("preference_target", ['PARTNER', 'SELF'])
 
-
-export const preferenceOptions = pgTable("preference_options", {
-	id: varchar({ length: 128 }).primaryKey().notNull(),
-	preferenceTypeId: varchar("preference_type_id", { length: 128 }),
-	value: varchar({ length: 100 }).notNull(),
-	displayName: varchar("display_name", { length: 100 }).notNull(),
-	updatedAt: timestamp("updated_at", { mode: 'string' }),
-	createdAt: timestamp("created_at", { mode: 'string' }).defaultNow().notNull(),
-	deletedAt: timestamp("deleted_at", { mode: 'string' }),
-	imageUrl: text("image_url"),
-});
 
 export const matchingRequests = pgTable("matching_requests", {
 	id: varchar({ length: 128 }).primaryKey().notNull(),
 	userId: varchar("user_id", { length: 128 }),
 	score: varchar({ length: 36 }),
-	updatedAt: timestamp("updated_at", { mode: 'string' }),
-	createdAt: timestamp("created_at", { mode: 'string' }).defaultNow().notNull(),
-	deletedAt: timestamp("deleted_at", { mode: 'string' }),
+	updatedAt: timestamp("updated_at", { withTimezone: true, mode: 'string' }),
+	createdAt: timestamp("created_at", { withTimezone: true, mode: 'string' }).defaultNow().notNull(),
+	deletedAt: timestamp("deleted_at", { withTimezone: true, mode: 'string' }),
+});
+
+export const preferenceOptions = pgTable("preference_options", {
+	id: varchar({ length: 128 }).primaryKey().notNull(),
+	imageUrl: text("image_url"),
+	preferenceTypeId: varchar("preference_type_id", { length: 128 }),
+	value: varchar({ length: 100 }).notNull(),
+	displayName: varchar("display_name", { length: 100 }).notNull(),
+	updatedAt: timestamp("updated_at", { withTimezone: true, mode: 'string' }),
+	createdAt: timestamp("created_at", { withTimezone: true, mode: 'string' }).defaultNow().notNull(),
+	deletedAt: timestamp("deleted_at", { withTimezone: true, mode: 'string' }),
 });
 
 export const preferenceTypes = pgTable("preference_types", {
@@ -29,9 +30,9 @@ export const preferenceTypes = pgTable("preference_types", {
 	name: varchar({ length: 100 }).notNull(),
 	multiSelect: boolean("multi_select").default(false).notNull(),
 	maximumChoiceCount: integer("maximum_choice_count").default(1).notNull(),
-	updatedAt: timestamp("updated_at", { mode: 'string' }),
-	createdAt: timestamp("created_at", { mode: 'string' }).defaultNow().notNull(),
-	deletedAt: timestamp("deleted_at", { mode: 'string' }),
+	updatedAt: timestamp("updated_at", { withTimezone: true, mode: 'string' }),
+	createdAt: timestamp("created_at", { withTimezone: true, mode: 'string' }).defaultNow().notNull(),
+	deletedAt: timestamp("deleted_at", { withTimezone: true, mode: 'string' }),
 }, (table) => [
 	unique("preference_types_code_unique").on(table.code),
 ]);
@@ -44,29 +45,9 @@ export const images = pgTable("images", {
 	mimeType: varchar("mime_type", { length: 100 }),
 	sizeInBytes: integer("size_in_bytes"),
 	isVerified: boolean("is_verified").default(false),
-	updatedAt: timestamp("updated_at", { mode: 'string' }),
-	createdAt: timestamp("created_at", { mode: 'string' }).defaultNow().notNull(),
-	deletedAt: timestamp("deleted_at", { mode: 'string' }),
-});
-
-export const userPreferenceOptions = pgTable("user_preference_options", {
-	id: varchar({ length: 128 }).primaryKey().notNull(),
-	userPreferenceId: varchar("user_preference_id", { length: 36 }).notNull(),
-	preferenceOptionId: varchar("preference_option_id", { length: 36 }).notNull(),
-	updatedAt: timestamp("updated_at", { mode: 'string' }),
-	createdAt: timestamp("created_at", { mode: 'string' }).defaultNow().notNull(),
-	deletedAt: timestamp("deleted_at", { mode: 'string' }),
-});
-
-export const userRangePreferences = pgTable("user_range_preferences", {
-	id: varchar({ length: 128 }).primaryKey().notNull(),
-	userPreferenceId: varchar("user_preference_id", { length: 36 }),
-	preferenceTypeId: varchar("preference_type_id", { length: 36 }),
-	minValue: integer("min_value"),
-	maxValue: integer("max_value"),
-	updatedAt: timestamp("updated_at", { mode: 'string' }),
-	createdAt: timestamp("created_at", { mode: 'string' }).defaultNow().notNull(),
-	deletedAt: timestamp("deleted_at", { mode: 'string' }),
+	updatedAt: timestamp("updated_at", { withTimezone: true, mode: 'string' }),
+	createdAt: timestamp("created_at", { withTimezone: true, mode: 'string' }).defaultNow().notNull(),
+	deletedAt: timestamp("deleted_at", { withTimezone: true, mode: 'string' }),
 });
 
 export const smsAuthorization = pgTable("sms_authorization", {
@@ -75,104 +56,22 @@ export const smsAuthorization = pgTable("sms_authorization", {
 	uniqueKey: varchar("unique_key", { length: 62 }).notNull(),
 	authorizationCode: varchar("authorization_code", { length: 12 }).notNull(),
 	isAuthorized: boolean("is_authorized").default(false).notNull(),
-	updatedAt: timestamp("updated_at", { mode: 'string' }),
-	createdAt: timestamp("created_at", { mode: 'string' }).defaultNow().notNull(),
-	deletedAt: timestamp("deleted_at", { mode: 'string' }),
+	updatedAt: timestamp("updated_at", { withTimezone: true, mode: 'string' }),
+	createdAt: timestamp("created_at", { withTimezone: true, mode: 'string' }).defaultNow().notNull(),
+	deletedAt: timestamp("deleted_at", { withTimezone: true, mode: 'string' }),
 });
-
-export const articles = pgTable("articles", {
-	id: varchar({ length: 128 }).primaryKey().notNull(),
-	authorId: varchar("author_id", { length: 128 }).notNull(),
-	content: varchar({ length: 255 }).notNull(),
-	anonymous: varchar({ length: 15 }),
-	emoji: varchar({ length: 10 }),
-	likeCount: integer("like_count").default(0).notNull(),
-	blindedAt: timestamp("blinded_at", { mode: 'string' }),
-	updatedAt: timestamp("updated_at", { mode: 'string' }),
-	createdAt: timestamp("created_at", { mode: 'string' }).defaultNow().notNull(),
-	deletedAt: timestamp("deleted_at", { mode: 'string' }),
-}, (table) => [
-	foreignKey({
-			columns: [table.authorId],
-			foreignColumns: [users.id],
-			name: "articles_author_id_users_id_fk"
-		}),
-]);
-
-export const users = pgTable("users", {
-	id: varchar({ length: 128 }).primaryKey().notNull(),
-	name: varchar({ length: 15 }).notNull(),
-	email: varchar({ length: 100 }).notNull(),
-	password: varchar({ length: 100 }).notNull(),
-	profileId: varchar("profile_id", { length: 36 }),
-	oauthProvider: varchar("oauth_provider", { length: 30 }),
-	refreshToken: varchar("refresh_token", { length: 500 }),
-	role: varchar({ length: 10 }).default('user').notNull(),
-	updatedAt: timestamp("updated_at", { mode: 'string' }),
-	createdAt: timestamp("created_at", { mode: 'string' }).defaultNow().notNull(),
-	deletedAt: timestamp("deleted_at", { mode: 'string' }),
-	phoneNumber: varchar("phone_number", { length: 16 }).notNull(),
-});
-
-export const matches = pgTable("matches", {
-	id: varchar({ length: 128 }).primaryKey().notNull(),
-	myId: varchar("my_id", { length: 128 }).notNull(),
-	matcherId: varchar("matcher_id", { length: 128 }),
-	score: numeric({ precision: 8, scale:  2 }).notNull(),
-	publishedAt: timestamp("published_at", { mode: 'string' }).notNull(),
-	type: varchar({ length: 30 }).notNull(),
-	updatedAt: timestamp("updated_at", { mode: 'string' }),
-	createdAt: timestamp("created_at", { mode: 'string' }).defaultNow().notNull(),
-	deletedAt: timestamp("deleted_at", { mode: 'string' }),
-	direct: boolean().default(false),
-}, (table) => [
-	foreignKey({
-			columns: [table.myId],
-			foreignColumns: [users.id],
-			name: "matches_my_id_users_id_fk"
-		}),
-	foreignKey({
-			columns: [table.matcherId],
-			foreignColumns: [users.id],
-			name: "matches_matcher_id_users_id_fk"
-		}),
-]);
-
-export const profiles = pgTable("profiles", {
-	id: varchar({ length: 128 }).primaryKey().notNull(),
-	userId: varchar("user_id", { length: 128 }).notNull(),
-	age: integer().notNull(),
-	gender: varchar({ length: 10 }).notNull(),
-	name: varchar({ length: 15 }).notNull(),
-	title: varchar({ length: 100 }),
-	instagramId: varchar("instagram_id", { length: 100 }),
-	introduction: varchar({ length: 255 }),
-	statusAt: varchar("status_at", { length: 36 }),
-	universityDetailId: varchar("university_detail_id", { length: 36 }),
-	updatedAt: timestamp("updated_at", { mode: 'string' }),
-	createdAt: timestamp("created_at", { mode: 'string' }).defaultNow().notNull(),
-	deletedAt: timestamp("deleted_at", { mode: 'string' }),
-	isMatchingEnable: boolean("is_matching_enable").default(true).notNull(),
-	rank: varchar({ length: 2 }).default('C'),
-}, (table) => [
-	foreignKey({
-			columns: [table.userId],
-			foreignColumns: [users.id],
-			name: "profiles_user_id_users_id_fk"
-		}),
-	unique("profiles_user_id_unique").on(table.userId),
-]);
 
 export const comments = pgTable("comments", {
 	id: varchar({ length: 128 }).primaryKey().notNull(),
 	authorId: varchar("author_id", { length: 36 }).notNull(),
-	postId: varchar("post_id", { length: 36 }).notNull(),
+	articleId: varchar("article_id", { length: 36 }).notNull(),
 	content: varchar({ length: 255 }).notNull(),
 	nickname: varchar({ length: 15 }).notNull(),
-	emoji: varchar({ length: 10 }),
-	updatedAt: timestamp("updated_at", { mode: 'string' }),
-	createdAt: timestamp("created_at", { mode: 'string' }).defaultNow().notNull(),
-	deletedAt: timestamp("deleted_at", { mode: 'string' }),
+	updatedAt: timestamp("updated_at", { withTimezone: true, mode: 'string' }),
+	createdAt: timestamp("created_at", { withTimezone: true, mode: 'string' }).defaultNow().notNull(),
+	deletedAt: timestamp("deleted_at", { withTimezone: true, mode: 'string' }),
+	parentId: varchar("parent_id", { length: 36 }),
+	blindedAt: timestamp("blinded_at", { mode: 'string' }),
 }, (table) => [
 	foreignKey({
 			columns: [table.authorId],
@@ -180,9 +79,14 @@ export const comments = pgTable("comments", {
 			name: "comments_author_id_users_id_fk"
 		}),
 	foreignKey({
-			columns: [table.postId],
+			columns: [table.parentId],
+			foreignColumns: [table.id],
+			name: "comments_parent_id_comments_id_fk"
+		}),
+	foreignKey({
+			columns: [table.articleId],
 			foreignColumns: [articles.id],
-			name: "comments_post_id_articles_id_fk"
+			name: "comments_article_id_articles_id_fk"
 		}),
 ]);
 
@@ -191,9 +95,9 @@ export const likes = pgTable("likes", {
 	userId: varchar("user_id", { length: 128 }).notNull(),
 	articleId: varchar("article_id", { length: 128 }).notNull(),
 	up: boolean().default(false).notNull(),
-	updatedAt: timestamp("updated_at", { mode: 'string' }),
-	createdAt: timestamp("created_at", { mode: 'string' }).defaultNow().notNull(),
-	deletedAt: timestamp("deleted_at", { mode: 'string' }),
+	updatedAt: timestamp("updated_at", { withTimezone: true, mode: 'string' }),
+	createdAt: timestamp("created_at", { withTimezone: true, mode: 'string' }).defaultNow().notNull(),
+	deletedAt: timestamp("deleted_at", { withTimezone: true, mode: 'string' }),
 }, (table) => [
 	foreignKey({
 			columns: [table.userId],
@@ -207,6 +111,186 @@ export const likes = pgTable("likes", {
 		}),
 ]);
 
+export const userRangePreferences = pgTable("user_range_preferences", {
+	id: varchar({ length: 128 }).primaryKey().notNull(),
+	userPreferenceId: varchar("user_preference_id", { length: 36 }),
+	preferenceTypeId: varchar("preference_type_id", { length: 36 }),
+	minValue: integer("min_value"),
+	maxValue: integer("max_value"),
+	updatedAt: timestamp("updated_at", { withTimezone: true, mode: 'string' }),
+	createdAt: timestamp("created_at", { withTimezone: true, mode: 'string' }).defaultNow().notNull(),
+	deletedAt: timestamp("deleted_at", { withTimezone: true, mode: 'string' }),
+});
+
+export const userPreferenceOptions = pgTable("user_preference_options", {
+	id: varchar({ length: 128 }).primaryKey().notNull(),
+	userPreferenceId: varchar("user_preference_id", { length: 36 }).notNull(),
+	preferenceOptionId: varchar("preference_option_id", { length: 36 }).notNull(),
+	updatedAt: timestamp("updated_at", { withTimezone: true, mode: 'string' }),
+	createdAt: timestamp("created_at", { withTimezone: true, mode: 'string' }).defaultNow().notNull(),
+	deletedAt: timestamp("deleted_at", { withTimezone: true, mode: 'string' }),
+	preferenceTarget: preferenceTarget("preference_target").default('PARTNER').notNull(),
+});
+
+export const users = pgTable("users", {
+	id: varchar({ length: 128 }).primaryKey().notNull(),
+	name: varchar({ length: 15 }).notNull(),
+	email: varchar({ length: 100 }),
+	password: varchar({ length: 100 }),
+	phoneNumber: varchar("phone_number", { length: 16 }).notNull(),
+	profileId: varchar("profile_id", { length: 36 }),
+	oauthProvider: varchar("oauth_provider", { length: 30 }),
+	refreshToken: varchar("refresh_token", { length: 500 }),
+	role: varchar({ length: 10 }).default('user').notNull(),
+	updatedAt: timestamp("updated_at", { withTimezone: true, mode: 'string' }),
+	createdAt: timestamp("created_at", { withTimezone: true, mode: 'string' }).defaultNow().notNull(),
+	deletedAt: timestamp("deleted_at", { withTimezone: true, mode: 'string' }),
+	suspendedAt: timestamp("suspended_at", { mode: 'string' }),
+});
+
+export const articleCategories = pgTable("article_categories", {
+	id: varchar({ length: 128 }).primaryKey().notNull(),
+	emojiUrl: text("emoji_url").notNull(),
+	displayName: varchar("display_name", { length: 20 }).notNull(),
+	updatedAt: timestamp("updated_at", { withTimezone: true, mode: 'string' }),
+	createdAt: timestamp("created_at", { withTimezone: true, mode: 'string' }).defaultNow().notNull(),
+	deletedAt: timestamp("deleted_at", { withTimezone: true, mode: 'string' }),
+	code: varchar({ length: 15 }).notNull(),
+});
+
+export const withdrawalReasons = pgTable("withdrawal_reasons", {
+	id: varchar({ length: 128 }).primaryKey().notNull(),
+	userId: varchar("user_id", { length: 128 }).notNull(),
+	reason: varchar().notNull(),
+	updatedAt: timestamp("updated_at", { withTimezone: true, mode: 'string' }),
+	createdAt: timestamp("created_at", { withTimezone: true, mode: 'string' }).defaultNow().notNull(),
+	deletedAt: timestamp("deleted_at", { withTimezone: true, mode: 'string' }),
+});
+
+export const matchingFailureLogs = pgTable("matching_failure_logs", {
+	id: varchar({ length: 128 }).primaryKey().notNull(),
+	userId: varchar("user_id", { length: 128 }).notNull(),
+	reason: text().notNull(),
+	updatedAt: timestamp("updated_at", { withTimezone: true, mode: 'string' }),
+	createdAt: timestamp("created_at", { withTimezone: true, mode: 'string' }).defaultNow().notNull(),
+	deletedAt: timestamp("deleted_at", { withTimezone: true, mode: 'string' }),
+}, (table) => [
+	foreignKey({
+			columns: [table.userId],
+			foreignColumns: [users.id],
+			name: "matching_failure_logs_user_id_users_id_fk"
+		}),
+]);
+
+export const hotArticles = pgTable("hot_articles", {
+	id: varchar({ length: 128 }).primaryKey().notNull(),
+	articleId: varchar("article_id", { length: 128 }).notNull(),
+	curatorComment: varchar("curator_comment", { length: 255 }),
+	updatedAt: timestamp("updated_at", { withTimezone: true, mode: 'string' }),
+	createdAt: timestamp("created_at", { withTimezone: true, mode: 'string' }).defaultNow().notNull(),
+	deletedAt: timestamp("deleted_at", { withTimezone: true, mode: 'string' }),
+}, (table) => [
+	foreignKey({
+			columns: [table.articleId],
+			foreignColumns: [articles.id],
+			name: "hot_articles_article_id_articles_id_fk"
+		}),
+]);
+
+export const profiles = pgTable("profiles", {
+	id: varchar({ length: 128 }).primaryKey().notNull(),
+	userId: varchar("user_id", { length: 128 }).notNull(),
+	age: integer().notNull(),
+	gender: varchar({ length: 10 }).notNull(),
+	name: varchar({ length: 15 }).notNull(),
+	title: varchar({ length: 100 }),
+	instagramId: varchar("instagram_id", { length: 100 }),
+	introduction: varchar({ length: 255 }),
+	universityDetailId: varchar("university_detail_id", { length: 36 }),
+	updatedAt: timestamp("updated_at", { withTimezone: true, mode: 'string' }),
+	createdAt: timestamp("created_at", { withTimezone: true, mode: 'string' }).defaultNow().notNull(),
+	deletedAt: timestamp("deleted_at", { withTimezone: true, mode: 'string' }),
+	isMatchingEnable: boolean("is_matching_enable").default(true).notNull(),
+	rank: varchar({ length: 7 }).default('UNKNOWN').notNull(),
+	mbti: varchar({ length: 4 }),
+	statusAt: varchar("status_at", { length: 16 }),
+}, (table) => [
+	foreignKey({
+			columns: [table.userId],
+			foreignColumns: [users.id],
+			name: "profiles_user_id_users_id_fk"
+		}),
+	unique("profiles_user_id_unique").on(table.userId),
+]);
+
+export const matches = pgTable("matches", {
+	id: varchar({ length: 128 }).primaryKey().notNull(),
+	myId: varchar("my_id", { length: 128 }).notNull(),
+	matcherId: varchar("matcher_id", { length: 128 }),
+	score: numeric({ precision: 8, scale:  2 }).notNull(),
+	publishedAt: timestamp("published_at", { withTimezone: true, mode: 'string' }).notNull(),
+	type: varchar({ length: 30 }).notNull(),
+	updatedAt: timestamp("updated_at", { withTimezone: true, mode: 'string' }),
+	createdAt: timestamp("created_at", { withTimezone: true, mode: 'string' }).defaultNow().notNull(),
+	deletedAt: timestamp("deleted_at", { withTimezone: true, mode: 'string' }),
+	direct: boolean().default(false),
+	expiredAt: timestamp("expired_at", { withTimezone: true, mode: 'string' }).notNull(),
+}, (table) => [
+	foreignKey({
+			columns: [table.myId],
+			foreignColumns: [users.id],
+			name: "matches_my_id_users_id_fk"
+		}),
+	foreignKey({
+			columns: [table.matcherId],
+			foreignColumns: [users.id],
+			name: "matches_matcher_id_users_id_fk"
+		}),
+]);
+
+export const additionalPreferences = pgTable("additional_preferences", {
+	id: varchar({ length: 128 }).primaryKey().notNull(),
+	goodMbti: varchar("good_mbti", { length: 4 }),
+	badMbti: varchar("bad_mbti", { length: 4 }),
+	profileId: varchar("profile_id").notNull(),
+	updatedAt: timestamp("updated_at", { withTimezone: true, mode: 'string' }),
+	createdAt: timestamp("created_at", { withTimezone: true, mode: 'string' }).defaultNow().notNull(),
+	deletedAt: timestamp("deleted_at", { withTimezone: true, mode: 'string' }),
+}, (table) => [
+	foreignKey({
+			columns: [table.profileId],
+			foreignColumns: [profiles.id],
+			name: "additional_preferences_profile_id_profiles_id_fk"
+		}),
+	unique("additional_preferences_profile_id_unique").on(table.profileId),
+]);
+
+export const articles = pgTable("articles", {
+	id: varchar({ length: 128 }).primaryKey().notNull(),
+	authorId: varchar("author_id", { length: 128 }).notNull(),
+	content: varchar({ length: 255 }).notNull(),
+	anonymous: varchar({ length: 15 }),
+	likeCount: integer("like_count").default(0).notNull(),
+	blindedAt: timestamp("blinded_at", { mode: 'string' }),
+	updatedAt: timestamp("updated_at", { withTimezone: true, mode: 'string' }),
+	createdAt: timestamp("created_at", { withTimezone: true, mode: 'string' }).defaultNow().notNull(),
+	deletedAt: timestamp("deleted_at", { withTimezone: true, mode: 'string' }),
+	categoryId: varchar("category_id", { length: 128 }).notNull(),
+	readCount: integer("read_count").default(0).notNull(),
+	title: varchar({ length: 30 }).notNull(),
+}, (table) => [
+	foreignKey({
+			columns: [table.authorId],
+			foreignColumns: [users.id],
+			name: "articles_author_id_users_id_fk"
+		}),
+	foreignKey({
+			columns: [table.categoryId],
+			foreignColumns: [articleCategories.id],
+			name: "articles_category_id_article_categories_id_fk"
+		}),
+]);
+
 export const payHistories = pgTable("pay_histories", {
 	id: varchar({ length: 128 }).primaryKey().notNull(),
 	amount: integer().notNull(),
@@ -214,13 +298,13 @@ export const payHistories = pgTable("pay_histories", {
 	method: varchar({ length: 50 }),
 	orderId: varchar("order_id", { length: 128 }),
 	orderName: varchar("order_name", { length: 30 }).notNull(),
-	paymentKey: varchar("payment_key", { length: 128 }),
-	paidAt: timestamp("paid_at", { mode: 'string' }),
-	updatedAt: timestamp("updated_at", { mode: 'string' }),
-	createdAt: timestamp("created_at", { mode: 'string' }).defaultNow().notNull(),
-	deletedAt: timestamp("deleted_at", { mode: 'string' }),
 	txId: varchar("tx_id"),
+	paymentKey: varchar("payment_key", { length: 128 }),
 	receiptUrl: text("receipt_url"),
+	paidAt: timestamp("paid_at", { mode: 'string' }),
+	updatedAt: timestamp("updated_at", { withTimezone: true, mode: 'string' }),
+	createdAt: timestamp("created_at", { withTimezone: true, mode: 'string' }).defaultNow().notNull(),
+	deletedAt: timestamp("deleted_at", { withTimezone: true, mode: 'string' }),
 }, (table) => [
 	foreignKey({
 			columns: [table.userId],
@@ -236,9 +320,9 @@ export const reports = pgTable("reports", {
 	reportedId: varchar("reported_id", { length: 128 }).notNull(),
 	reason: varchar({ length: 255 }),
 	status: varchar({ length: 15 }),
-	updatedAt: timestamp("updated_at", { mode: 'string' }),
-	createdAt: timestamp("created_at", { mode: 'string' }).defaultNow().notNull(),
-	deletedAt: timestamp("deleted_at", { mode: 'string' }),
+	updatedAt: timestamp("updated_at", { withTimezone: true, mode: 'string' }),
+	createdAt: timestamp("created_at", { withTimezone: true, mode: 'string' }).defaultNow().notNull(),
+	deletedAt: timestamp("deleted_at", { withTimezone: true, mode: 'string' }),
 }, (table) => [
 	foreignKey({
 			columns: [table.postId],
@@ -257,6 +341,25 @@ export const reports = pgTable("reports", {
 		}),
 ]);
 
+export const tickets = pgTable("tickets", {
+	id: varchar({ length: 128 }).primaryKey().notNull(),
+	name: varchar({ length: 30 }).notNull(),
+	userId: varchar("user_id", { length: 128 }).notNull(),
+	status: varchar({ length: 10 }).notNull(),
+	type: varchar({ length: 10 }).notNull(),
+	expiredAt: timestamp("expired_at", { mode: 'string' }),
+	updatedAt: timestamp("updated_at", { withTimezone: true, mode: 'string' }),
+	createdAt: timestamp("created_at", { withTimezone: true, mode: 'string' }).defaultNow().notNull(),
+	deletedAt: timestamp("deleted_at", { withTimezone: true, mode: 'string' }),
+	usedAt: timestamp("used_at", { mode: 'string' }),
+}, (table) => [
+	foreignKey({
+			columns: [table.userId],
+			foreignColumns: [users.id],
+			name: "tickets_user_id_users_id_fk"
+		}),
+]);
+
 export const universityDetails = pgTable("university_details", {
 	id: varchar({ length: 128 }).primaryKey().notNull(),
 	userId: varchar("user_id", { length: 36 }).notNull(),
@@ -265,9 +368,9 @@ export const universityDetails = pgTable("university_details", {
 	authentication: boolean().default(false).notNull(),
 	grade: varchar({ length: 10 }).notNull(),
 	studentNumber: varchar("student_number", { length: 10 }).notNull(),
-	updatedAt: timestamp("updated_at", { mode: 'string' }),
-	createdAt: timestamp("created_at", { mode: 'string' }).defaultNow().notNull(),
-	deletedAt: timestamp("deleted_at", { mode: 'string' }),
+	updatedAt: timestamp("updated_at", { withTimezone: true, mode: 'string' }),
+	createdAt: timestamp("created_at", { withTimezone: true, mode: 'string' }).defaultNow().notNull(),
+	deletedAt: timestamp("deleted_at", { withTimezone: true, mode: 'string' }),
 }, (table) => [
 	foreignKey({
 			columns: [table.userId],
@@ -280,9 +383,9 @@ export const userPreferences = pgTable("user_preferences", {
 	id: varchar({ length: 128 }).primaryKey().notNull(),
 	userId: varchar("user_id", { length: 36 }).notNull(),
 	distanceMax: varchar("distance_max", { length: 36 }),
-	updatedAt: timestamp("updated_at", { mode: 'string' }),
-	createdAt: timestamp("created_at", { mode: 'string' }).defaultNow().notNull(),
-	deletedAt: timestamp("deleted_at", { mode: 'string' }),
+	updatedAt: timestamp("updated_at", { withTimezone: true, mode: 'string' }),
+	createdAt: timestamp("created_at", { withTimezone: true, mode: 'string' }).defaultNow().notNull(),
+	deletedAt: timestamp("deleted_at", { withTimezone: true, mode: 'string' }),
 }, (table) => [
 	foreignKey({
 			columns: [table.userId],
@@ -292,33 +395,15 @@ export const userPreferences = pgTable("user_preferences", {
 	unique("user_preferences_user_id_unique").on(table.userId),
 ]);
 
-export const tickets = pgTable("tickets", {
-	id: varchar({ length: 128 }).primaryKey().notNull(),
-	userId: varchar("user_id", { length: 128 }).notNull(),
-	status: varchar({ length: 10 }).notNull(),
-	type: varchar({ length: 10 }).notNull(),
-	expiredAt: timestamp("expired_at", { mode: 'string' }),
-	updatedAt: timestamp("updated_at", { mode: 'string' }),
-	createdAt: timestamp("created_at", { mode: 'string' }).defaultNow().notNull(),
-	deletedAt: timestamp("deleted_at", { mode: 'string' }),
-	name: varchar({ length: 30 }).notNull(),
-}, (table) => [
-	foreignKey({
-			columns: [table.userId],
-			foreignColumns: [users.id],
-			name: "tickets_user_id_users_id_fk"
-		}),
-]);
-
 export const profileImages = pgTable("profile_images", {
 	id: varchar({ length: 128 }).primaryKey().notNull(),
 	profileId: varchar("profile_id", { length: 36 }).notNull(),
 	imageId: varchar("image_id", { length: 36 }).notNull(),
 	imageOrder: integer("image_order").notNull(),
 	isMain: boolean("is_main").default(false).notNull(),
-	updatedAt: timestamp("updated_at", { mode: 'string' }),
-	createdAt: timestamp("created_at", { mode: 'string' }).defaultNow().notNull(),
-	deletedAt: timestamp("deleted_at", { mode: 'string' }),
+	updatedAt: timestamp("updated_at", { withTimezone: true, mode: 'string' }),
+	createdAt: timestamp("created_at", { withTimezone: true, mode: 'string' }).defaultNow().notNull(),
+	deletedAt: timestamp("deleted_at", { withTimezone: true, mode: 'string' }),
 }, (table) => [
 	foreignKey({
 			columns: [table.profileId],

--- a/src/database/database.module.ts
+++ b/src/database/database.module.ts
@@ -13,7 +13,7 @@ import { DatabaseService } from './database.service';
       provide: 'DRIZZLE_ORM',
       inject: [ConfigService],
       useFactory: async (configService: ConfigService) => {
-        const env = configService.get('NODE_ENV');
+        const env = configService.get('NODE_ENV') as string;
 
         const pool = new Pool({
           user: configService.get('DATABASE_USER'),
@@ -30,7 +30,6 @@ import { DatabaseService } from './database.service';
           casing: 'snake_case',
           logger: {
             logQuery: (query, params) => {
-              return;
               if (env !== 'development') return;
               logger.debug(`쿼리: ${query}`);
               if (params && params.length > 0) {

--- a/src/database/schema/addtional_preferences.ts
+++ b/src/database/schema/addtional_preferences.ts
@@ -1,0 +1,14 @@
+import { pgTable, varchar } from 'drizzle-orm/pg-core';
+import { timestamps, uuid } from '@database/schema/helper';
+import { profiles } from './profiles';
+
+export const additionalPreferences = pgTable('additional_preferences', {
+  id: uuid(),
+  goodMbti: varchar('good_mbti', { length: 4 }),
+  badMbti: varchar('bad_mbti', { length: 4 }),
+  profileId: varchar('profile_id')
+    .references(() => profiles.id)
+    .notNull()
+    .unique(),
+  ...timestamps,
+});

--- a/src/database/schema/profiles.ts
+++ b/src/database/schema/profiles.ts
@@ -13,7 +13,10 @@ export enum UserRank {
 
 export const profiles = pgTable('profiles', {
   id: uuid(),
-  userId: varchar('user_id', { length: 128 }).references(() => users.id).notNull().unique(),
+  userId: varchar('user_id', { length: 128 })
+    .references(() => users.id)
+    .notNull()
+    .unique(),
   age: integer('age').notNull(),
   gender: varchar('gender', { length: 10 }).$type<Gender>().notNull(),
   name: varchar('name', { length: 15 }).notNull(),
@@ -22,7 +25,9 @@ export const profiles = pgTable('profiles', {
   instagramId: varchar('instagram_id', { length: 100 }),
   is_matching_enable: boolean('is_matching_enable').default(true).notNull(),
   introduction: varchar('introduction', { length: 255 }),
-  rank: varchar('rank', { length: 7, enum: ['S', 'A', 'B', 'C', 'UNKNOWN'] }).default('UNKNOWN').notNull(),
+  rank: varchar('rank', { length: 7, enum: ['S', 'A', 'B', 'C', 'UNKNOWN'] })
+    .default('UNKNOWN')
+    .notNull(),
   universityDetailId: varchar('university_detail_id', { length: 36 }),
   ...timestamps,
 });

--- a/src/database/schema/relations/additional_preferences.relation.ts
+++ b/src/database/schema/relations/additional_preferences.relation.ts
@@ -1,0 +1,13 @@
+import { relations } from 'drizzle-orm';
+import { additionalPreferences } from '../addtional_preferences';
+import { profiles } from '../profiles';
+
+export const additionalPreferencesRelations = relations(
+  additionalPreferences,
+  ({ one }) => ({
+    profile: one(profiles, {
+      fields: [additionalPreferences.profileId],
+      references: [profiles.id],
+    }),
+  }),
+);

--- a/src/database/schema/relations/profiles.relations.ts
+++ b/src/database/schema/relations/profiles.relations.ts
@@ -5,7 +5,7 @@ import { universityDetails } from '../university_details';
 import { profileImages } from '../profile_images';
 import { userPreferences } from '../user_preferences';
 import { matchingRequests } from '../matching_requests';
-import { matches } from '../matches';
+import { additionalPreferences } from '../addtional_preferences';
 
 export const profilesRelations = relations(profiles, ({ one, many }) => ({
   user: one(users, {
@@ -19,4 +19,8 @@ export const profilesRelations = relations(profiles, ({ one, many }) => ({
   profileImages: many(profileImages),
   userPreference: one(userPreferences),
   matchingRequests: many(matchingRequests),
+  additionalPreference: one(additionalPreferences, {
+    fields: [profiles.id],
+    references: [additionalPreferences.profileId],
+  }),
 }));

--- a/src/database/schema/schema.ts
+++ b/src/database/schema/schema.ts
@@ -22,6 +22,7 @@ import { articleCategory } from './article_categories';
 import { hotArticles } from './hot_articles';
 import { withdrawalReasons } from './withdrawal_reasons';
 import { matchingFailureLogs } from './matching_failure_logs';
+import { additionalPreferences } from './addtional_preferences';
 
 // 관계형 매핑 파일 가져오기
 import './relations';
@@ -57,6 +58,7 @@ export {
   articleCategory,
   hotArticles,
   matchingFailureLogs,
+  additionalPreferences,
 };
 
 // 모든 테이블 스키마를 배열로 내보내기
@@ -83,4 +85,5 @@ export const schemas = [
   articleCategory,
   hotArticles,
   matchingFailureLogs,
+  additionalPreferences,
 ];

--- a/src/database/schema/user_preferences.ts
+++ b/src/database/schema/user_preferences.ts
@@ -4,7 +4,10 @@ import { users } from './users';
 
 export const userPreferences = pgTable('user_preferences', {
   id: uuid().primaryKey(),
-  userId: varchar('user_id', { length: 36 }).references(() => users.id).unique().notNull(),
+  userId: varchar('user_id', { length: 36 })
+    .references(() => users.id)
+    .unique()
+    .notNull(),
   distanceMax: varchar('distance_max', { length: 36 }),
   ...timestamps,
 });

--- a/src/types/user.ts
+++ b/src/types/user.ts
@@ -1,5 +1,5 @@
-import { UserRank } from "@/database/schema/profiles";
-import { Gender } from "./enum";
+import { UserRank } from '@/database/schema/profiles';
+import { Gender } from './enum';
 
 export interface ProfileDetails {
   id: string;
@@ -15,9 +15,7 @@ export interface ProfileDetails {
 
 export type ProfileSummary = Omit<
   ProfileDetails,
-  'userId' |
-  'universityDetailId' |
-  'statusAt'
+  'userId' | 'universityDetailId' | 'statusAt'
 >;
 
 export interface ProfileImage {
@@ -61,7 +59,7 @@ export type Preference = {
   multiple: boolean;
   optionDisplayName: string;
   maximumChoiceCount: number;
-}
+};
 
 export interface PreferenceTypeGroup {
   typeName: string;
@@ -72,7 +70,6 @@ export interface PreferenceList extends PreferenceTypeGroup {
   multiple: boolean;
   maximumChoiceCount: number;
 }
-
 
 export interface UniversityDetail {
   name: string;
@@ -93,6 +90,7 @@ export interface UserProfile {
   instagramId: string | null;
   universityDetails: UniversityDetail | null;
   preferences: PreferenceTypeGroup[];
+  characteristics: PreferenceTypeGroup[];
 }
 
 export type CommonProfile = Omit<UserProfile, 'rank'>;
@@ -107,4 +105,9 @@ export interface UserDetails {
   phoneNumber: string;
   instagramId: string | null;
   universityDetails: UniversityDetail | null;
+}
+
+export interface MbtiPreferences {
+  goodMbti: string;
+  badMbti: string;
 }

--- a/src/user/controller/preference.controller.ts
+++ b/src/user/controller/preference.controller.ts
@@ -4,20 +4,20 @@ import { ProfileService } from '../services/profile.service';
 import { CurrentUser, Roles } from '@/auth/decorators';
 import { Role } from '@/auth/domain/user-role.enum';
 import {
+  ApiBearerAuth,
   ApiOperation,
   ApiResponse,
   ApiTags,
-  ApiBearerAuth,
 } from '@nestjs/swagger';
 import { AuthenticationUser } from '@/types';
-import { PreferenceSave, SelfPreferenceSave } from '../dto/profile.dto';
-import { ProfileDocs } from '../docs/profile.docs';
+import { PreferenceSave, SelfPreferencesSave } from '../dto/profile.dto';
+import { ProfileDocs } from '@/user/docs';
 import { EventEmitter2 } from '@nestjs/event-emitter';
 import { ProfileUpdatedEvent } from '@/events/profile-updated.event';
 
 @ApiTags('이상형')
-@ApiBearerAuth('access-token')
 @Controller('preferences')
+@ApiBearerAuth('access-token')
 @Roles(Role.USER, Role.ADMIN)
 export class PreferenceController {
   constructor(
@@ -99,7 +99,7 @@ export class PreferenceController {
   })
   async updateSelfPreferences(
     @CurrentUser() user: AuthenticationUser,
-    @Body() data: SelfPreferenceSave,
+    @Body() data: SelfPreferencesSave,
   ) {
     const updatedProfile = await this.profileService.updateSelfPreferences(
       user.id,

--- a/src/user/data/preference.schema.ts
+++ b/src/user/data/preference.schema.ts
@@ -12,10 +12,10 @@ export const preferenceTypeExamples = {
       { id: '2', displayName: '조용함' },
       { id: '3', displayName: '배려심' },
       { id: '4', displayName: '솔직함' },
-      { id: '5', displayName: '유머러스' }
-    ]
+      { id: '5', displayName: '유머러스' },
+    ],
   },
-  
+
   // 연애 스타일
   datingStyle: {
     typeName: '연애 스타일',
@@ -23,10 +23,10 @@ export const preferenceTypeExamples = {
       { id: '1', displayName: '적극적' },
       { id: '2', displayName: '다정다감' },
       { id: '3', displayName: '츤데레' },
-      { id: '4', displayName: '로맨틱' }
-    ]
+      { id: '4', displayName: '로맨틱' },
+    ],
   },
-  
+
   // 라이프스타일
   lifestyle: {
     typeName: '라이프스타일',
@@ -34,30 +34,30 @@ export const preferenceTypeExamples = {
       { id: '1', displayName: '아침형' },
       { id: '2', displayName: '밤형' },
       { id: '3', displayName: '집순이/집돌이' },
-      { id: '4', displayName: '외향적' }
-    ]
+      { id: '4', displayName: '외향적' },
+    ],
   },
-  
+
   // 음주 선호도
   drinking: {
     typeName: '음주',
     options: [
       { id: '1', displayName: '안 마심' },
       { id: '2', displayName: '가끔 마심' },
-      { id: '3', displayName: '자주 마심' }
-    ]
+      { id: '3', displayName: '자주 마심' },
+    ],
   },
-  
+
   // 흡연 선호도
   smoking: {
     typeName: '흡연',
     options: [
       { id: '1', displayName: '비흡연' },
       { id: '2', displayName: '가끔 흡연' },
-      { id: '3', displayName: '매일 흡연' }
-    ]
+      { id: '3', displayName: '매일 흡연' },
+    ],
   },
-  
+
   // MBTI 유형
   mbti: {
     typeName: 'MBTI',
@@ -77,9 +77,9 @@ export const preferenceTypeExamples = {
       { id: '13', displayName: 'ESTJ' },
       { id: '14', displayName: 'ESFJ' },
       { id: '15', displayName: 'ENFJ' },
-      { id: '16', displayName: 'ENTJ' }
-    ]
-  }
+      { id: '16', displayName: 'ENTJ' },
+    ],
+  },
 };
 
 // 선호도 목록 응답 예시 데이터
@@ -91,10 +91,10 @@ export const preferenceListResponseExample = [
       { id: '01HFGXS6YW2222222222BBBBB', displayName: '조용함' },
       { id: '01HFGXS6YW3333333333CCCCC', displayName: '배려심' },
       { id: '01HFGXS6YW4444444444DDDDD', displayName: '솔직함' },
-      { id: '01HFGXS6YW5555555555EEEEE', displayName: '유머러스' }
+      { id: '01HFGXS6YW5555555555EEEEE', displayName: '유머러스' },
     ],
     multiple: true,
-    maximumChoiceCount: 3
+    maximumChoiceCount: 3,
   },
   {
     typeName: '연애 스타일',
@@ -102,10 +102,10 @@ export const preferenceListResponseExample = [
       { id: '01HFGXS6YW6666666666FFFFF', displayName: '적극적' },
       { id: '01HFGXS6YW7777777777GGGGG', displayName: '다정다감' },
       { id: '01HFGXS6YW8888888888HHHHH', displayName: '츤데레' },
-      { id: '01HFGXS6YW9999999999IIIII', displayName: '로맨틱' }
+      { id: '01HFGXS6YW9999999999IIIII', displayName: '로맨틱' },
     ],
     multiple: true,
-    maximumChoiceCount: 2
+    maximumChoiceCount: 2,
   },
   {
     typeName: 'MBTI',
@@ -113,11 +113,11 @@ export const preferenceListResponseExample = [
       { id: '01HFGXS6YWAAAAAAAAAJJJJJ', displayName: 'ISTJ' },
       { id: '01HFGXS6YWBBBBBBBBBKKKKK', displayName: 'ISFJ' },
       { id: '01HFGXS6YWCCCCCCCCCLLLL', displayName: 'INFJ' },
-      { id: '01HFGXS6YWDDDDDDDDDMMMMM', displayName: 'INTJ' }
+      { id: '01HFGXS6YWDDDDDDDDDMMMMM', displayName: 'INTJ' },
     ],
     multiple: false,
-    maximumChoiceCount: 1
-  }
+    maximumChoiceCount: 1,
+  },
 ];
 
 // 선호도 저장 요청 예시 데이터
@@ -125,17 +125,20 @@ export const preferenceSaveExample = {
   data: [
     {
       preferenceTypeId: '01HFGXS6YW1234567890ABCDE',
-      preferenceOptionIds: ['01HFGXS6YW1111111111AAAAA', '01HFGXS6YW2222222222BBBBB']
+      preferenceOptionIds: [
+        '01HFGXS6YW1111111111AAAAA',
+        '01HFGXS6YW2222222222BBBBB',
+      ],
     },
     {
       preferenceTypeId: '01HFGXS6YW5678901234FGHIJ',
-      preferenceOptionIds: ['01HFGXS6YW3333333333CCCCC']
-    }
-  ]
+      preferenceOptionIds: ['01HFGXS6YW3333333333CCCCC'],
+    },
+  ],
 };
 
 // 선호도 저장 응답 예시 데이터
 export const preferenceSaveResponseExample = {
   success: true,
-  message: '선호도가 성공적으로 저장되었습니다.'
+  message: '선호도가 성공적으로 저장되었습니다.',
 };

--- a/src/user/dto/preference-response.dto.ts
+++ b/src/user/dto/preference-response.dto.ts
@@ -6,13 +6,13 @@ import { ApiProperty } from '@nestjs/swagger';
 export class PreferenceOptionDto {
   @ApiProperty({
     description: '선호도 옵션 ID',
-    example: '01HFGXS6YW1111111111AAAAA'
+    example: '01HFGXS6YW1111111111AAAAA',
   })
   id: string;
 
   @ApiProperty({
     description: '선호도 옵션 표시 이름',
-    example: '활발함'
+    example: '활발함',
   })
   displayName: string;
 }
@@ -23,25 +23,25 @@ export class PreferenceOptionDto {
 export class PreferenceTypeDto {
   @ApiProperty({
     description: '선호도 타입 이름',
-    example: '성격'
+    example: '성격',
   })
   typeName: string;
 
   @ApiProperty({
     description: '선호도 옵션 목록',
-    type: [PreferenceOptionDto]
+    type: [PreferenceOptionDto],
   })
   options: PreferenceOptionDto[];
 
   @ApiProperty({
     description: '다중 선택 가능 여부',
-    example: true
+    example: true,
   })
   multiple: boolean;
 
   @ApiProperty({
     description: '최대 선택 가능 개수',
-    example: 3
+    example: 3,
   })
   maximumChoiceCount: number;
 }
@@ -52,14 +52,14 @@ export class PreferenceTypeDto {
 export class PreferenceSaveItemDto {
   @ApiProperty({
     description: '선호도 타입 ID',
-    example: '01HFGXS6YW1234567890ABCDE'
+    example: '01HFGXS6YW1234567890ABCDE',
   })
   preferenceTypeId: string;
 
   @ApiProperty({
     description: '선택한 선호도 옵션 ID 목록',
     example: ['01HFGXS6YW1111111111AAAAA', '01HFGXS6YW2222222222BBBBB'],
-    type: [String]
+    type: [String],
   })
   preferenceOptionIds: string[];
 }
@@ -70,7 +70,7 @@ export class PreferenceSaveItemDto {
 export class PreferenceSaveRequestDto {
   @ApiProperty({
     description: '선호도 저장 데이터',
-    type: [PreferenceSaveItemDto]
+    type: [PreferenceSaveItemDto],
   })
   data: PreferenceSaveItemDto[];
 }
@@ -81,13 +81,13 @@ export class PreferenceSaveRequestDto {
 export class PreferenceSaveResponseDto {
   @ApiProperty({
     description: '성공 여부',
-    example: true
+    example: true,
   })
   success: boolean;
 
   @ApiProperty({
     description: '응답 메시지',
-    example: '선호도가 성공적으로 저장되었습니다.'
+    example: '선호도가 성공적으로 저장되었습니다.',
   })
   message: string;
 }
@@ -98,20 +98,20 @@ export class PreferenceSaveResponseDto {
 export class BadRequestResponseDto {
   @ApiProperty({
     description: '상태 코드',
-    example: 400
+    example: 400,
   })
   statusCode: number;
 
   @ApiProperty({
     description: '오류 메시지 목록',
     example: ['data must be an array'],
-    type: [String]
+    type: [String],
   })
   message: string[];
 
   @ApiProperty({
     description: '오류 유형',
-    example: 'Bad Request'
+    example: 'Bad Request',
   })
   error: string;
 }

--- a/src/user/dto/profile.dto.ts
+++ b/src/user/dto/profile.dto.ts
@@ -1,22 +1,22 @@
-import { ApiProperty } from "@nestjs/swagger";
-import { IsArray, IsNotEmpty, IsString, ValidateNested } from "class-validator";
-import { Type } from "class-transformer";
+import { ApiProperty } from '@nestjs/swagger';
+import { IsArray, IsNotEmpty, IsString, ValidateNested } from 'class-validator';
+import { Type } from 'class-transformer';
 
 export class PreferenceData {
   @ApiProperty({
     example: '문신 선호도',
-    description: '옵션 타입의 이름'
+    description: '옵션 타입의 이름',
   })
   @IsString()
   @IsNotEmpty()
   typeName: string;
-  
+
   @ApiProperty({
     example: [
       'ed4a1fa2-8f26-4862-8567-878a069ee524',
       'ed4a1fa2-8f26-4862-8567-878a069ee526',
     ],
-    description: '옵션 ID 리스트'
+    description: '옵션 ID 리스트',
   })
   @IsArray()
   @IsString({ each: true })
@@ -29,15 +29,11 @@ export class PreferenceSave {
     example: [
       {
         typeName: '문신 선호도',
-        optionIds: [
-          '1fc730ec-ceed-4820-a55e-2bbec6bf3a80',
-        ]
+        optionIds: ['1fc730ec-ceed-4820-a55e-2bbec6bf3a80'],
       },
       {
         typeName: '음주 선호도',
-        optionIds: [
-          'a0291d73-cdeb-4ba3-9b5a-f6e6c573c54c'
-        ]
+        optionIds: ['a0291d73-cdeb-4ba3-9b5a-f6e6c573c54c'],
       },
       {
         typeName: '성격 유형',
@@ -45,10 +41,10 @@ export class PreferenceSave {
           '8dc5e263-e4b1-4975-8ec9-faf905a8dd7e',
           '700c83fa-b614-483b-9556-750b7d70d3a1',
           '1d9cad0b-9065-4ee8-8c15-b24527f64407',
-        ]
-      }
+        ],
+      },
     ],
-    type: [PreferenceData]
+    type: [PreferenceData],
   })
   @IsArray()
   @ValidateNested({ each: true })
@@ -63,46 +59,116 @@ export default class ProfileDto {
 export class InstagramId {
   @ApiProperty({
     example: '@.somqai3',
-    description: '인스타그램 ID'
+    description: '인스타그램 ID',
   })
   @IsString()
   @IsNotEmpty()
   instagramId: string;
 }
 
-
 export class MbtiUpdate {
   @ApiProperty({
     example: 'INFP',
-    description: 'MBTI'
+    description: 'MBTI',
   })
   @IsString()
   @IsNotEmpty()
   mbti: string;
 }
 
-export class SelfPreferenceSave {
+export class MbtiPreferencesRequest {
   @ApiProperty({
-    description: '본인 성향 데이터 배열',
+    example: 'INFP',
+    description: '선호하는 MBTI',
+  })
+  @IsString()
+  @IsNotEmpty()
+  goodMbti: string;
+
+  @ApiProperty({
+    example: 'INFP',
+    description: '싫어하는 MBTI',
+  })
+  @IsString()
+  @IsNotEmpty()
+  badMbti: string;
+}
+
+export class SelfPreferencesSave {
+  @ApiProperty({
+    description: 'MBTI 선호도 데이터',
+    example: {
+      goodMbti: 'INFP',
+      badMbti: 'ESTJ',
+    },
+    type: MbtiPreferencesRequest,
+  })
+  @ValidateNested({ each: true })
+  @Type(() => MbtiPreferencesRequest)
+  additional: MbtiPreferencesRequest;
+
+  @ApiProperty({
+    description: '사용자 성향 선호도 데이터 배열',
     example: [
       {
-        typeName: '성격 유형',
+        typeName: '선호 나이대',
+        optionIds: ['977daf95-b50e-4894-aea9-c6e64c78a90d'],
+      },
+      {
+        typeName: '연애 스타일',
         optionIds: [
-          '8dc5e263-e4b1-4975-8ec9-faf905a8dd7e',
-          '700c83fa-b614-483b-9556-750b7d70d3a1',
-        ]
+          '44f4e49f-3060-41d7-a0ce-331258c06324',
+          '6b128c16-1e9b-4256-8bf7-27f68c7cf0c1',
+          '9f6610b4-cd3b-41de-8cc0-06c7e7afa204',
+        ],
+      },
+      {
+        typeName: '음주 선호도',
+        optionIds: ['080e5185-5bd8-47e9-9ce2-eb9ff64fe178'],
+      },
+      {
+        typeName: '관심사',
+        optionIds: [
+          '394e7fcc-5141-4603-8d48-6ba8efe42e0a',
+          'c84070de-4194-492a-84d3-18071e7f9e14',
+          'bd962b7b-b37d-4833-aed5-a73588c307f8',
+          '45f82a3a-621a-44c0-85e8-7fb5b34eaaf6',
+          '9f0fb1cd-d364-433a-a371-5d985979255f',
+        ],
       },
       {
         typeName: '라이프스타일',
         optionIds: [
-          '1d9cad0b-9065-4ee8-8c15-b24527f64407',
-        ]
-      }
+          '56a3cfcc-3045-469c-ae98-7b1c62ad8df6',
+          'ad1ac46f-d8e8-45f2-ac0a-e1bb63141137',
+          '457e936f-c451-433a-9dd4-20638c7db55d',
+        ],
+      },
+      {
+        typeName: 'MBTI 유형',
+        optionIds: ['2cd83de2-290a-4bcd-94d9-aaac1055d030'],
+      },
+      {
+        typeName: '군필 여부',
+        optionIds: ['01HNGW1234567890ABCDEF001'],
+      },
+      {
+        typeName: '성격 유형',
+        optionIds: ['13a5b677-2cca-4776-91ed-aac8c08e0045'],
+      },
+      {
+        typeName: '흡연 선호도',
+        optionIds: ['dce1747a-f347-4812-8220-b931aceb2ded'],
+      },
+      {
+        typeName: '문신 선호도',
+        optionIds: ['21fd9662-c281-4294-a800-a7a0252fe637'],
+      },
     ],
-    type: [PreferenceData]
+    type: [PreferenceData],
   })
-  @IsArray()
   @ValidateNested({ each: true })
+  @IsArray()
   @Type(() => PreferenceData)
-  data: PreferenceData[];
+  preferences: PreferenceData[];
 }


### PR DESCRIPTION
## Summary
- 본인 성향과 이상형 선호도 분리를 위한 preference_target 컬럼 추가
- 추가 MBTI 선호도 저장을 위한 additional_preferences 테이블 생성
- SelfPreferencesSave API Swagger 문서 개선
- 매칭 로직 및 프로필 업데이트 이벤트 리팩토링

## Changes
- **데이터베이스 스키마**: preference_target ENUM 타입 추가, additional_preferences 테이블 생성
- **API 문서**: SelfPreferencesSave 클래스에 상세한 Swagger 문서 추가
- **매칭 로직**: 본인 성향과 이상형 선호도 분리 로직 적용
- **프로필 서비스**: 추가 선호도 저장 기능 구현

## Test plan
- [ ] 본인 성향 저장 API 테스트
- [ ] 이상형 선호도 저장 API 테스트
- [ ] 매칭 로직 동작 확인
- [ ] 데이터베이스 마이그레이션 테스트

🤖 Generated with [Claude Code](https://claude.ai/code)