### PR TITLE
feat: 본인인증 정보로 사용자 데이터 자동 업데이트 기능 추가

### DIFF
--- a/src/auth/repository/auth.repository.ts
+++ b/src/auth/repository/auth.repository.ts
@@ -228,7 +228,6 @@ export class AuthRepository {
     const now = new Date();
 
     return await this.db.transaction(async (tx) => {
-      // users 테이블 업데이트
       await tx.update(users)
         .set({
           name: certificationInfo.name,
@@ -238,7 +237,6 @@ export class AuthRepository {
         })
         .where(and(eq(users.id, userId), isNull(users.deletedAt)));
 
-      // profiles 테이블 업데이트
       await tx.update(profiles)
         .set({
           name: certificationInfo.name,

--- a/src/auth/services/auth.service.ts
+++ b/src/auth/services/auth.service.ts
@@ -87,7 +87,6 @@ export class AuthService {
         };
       }
 
-      // 기존 사용자의 본인인증 정보 업데이트
       const updatedUserInfo = await this.authRepository.updateUserWithCertification(
         existingUser.id,
         {


### PR DESCRIPTION
<img width="942" alt="image" src="https://github.com/user-attachments/assets/c98522ca-fb6d-4e4b-ae69-a0a4b5838fc4" />

# 📝 변경 사항
## 주요 기능
기존 사용자가 pass-login 시 포트원 본인인증 정보로 사용자 데이터 자동 업데이트
생년월일 기반 만나이 자동 계산 로직 추가
트랜잭션을 통한 users/profiles 테이블 동시 업데이트
업데이트되는 정보
## users 테이블
name: 포트원 실명
phone_number: 포트원 휴대폰 번호
birthday: 포트원 생년월일
updated_at: 현재 타임스탬프

## profiles 테이블
name: 포트원 실명
gender: 포트원 성별 정보
age: 생년월일 기반 계산된 만나이
updated_at: 현재 타임스탬프
