### PR TITLE
feat: 스토어 버전 관리 API 구현

### DIFF
--- a/src/config/redis/redis.service.ts
+++ b/src/config/redis/redis.service.ts
@@ -125,4 +125,30 @@ export class RedisService {
   pipeline() {
     return this.redisClient.pipeline();
   }
+
+  /**
+   * JSON 객체 저장
+   * @param key Redis 키
+   * @param value 저장할 객체
+   * @param ttl TTL (초)
+   */
+  async setObject<T>(key: string, value: T, ttl?: number): Promise<string> {
+    return await this.set(key, JSON.stringify(value), ttl);
+  }
+
+  /**
+   * JSON 객체 조회
+   * @param key Redis 키
+   */
+  async getObject<T>(key: string): Promise<T | null> {
+    const value = await this.get(key);
+    if (!value) return null;
+    try {
+      const parsed: unknown = JSON.parse(value);
+      return parsed as T;
+    } catch (error) {
+      this.logger.error(`JSON 파싱 실패: ${key}`, error);
+      return null;
+    }
+  }
 }

--- a/src/config/version/dto/version-response.dto.ts
+++ b/src/config/version/dto/version-response.dto.ts
@@ -1,0 +1,15 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export class VersionResponse {
+  @ApiProperty({
+    description: '앱 버전',
+    example: '1.0.0',
+  })
+  version: string;
+
+  @ApiProperty({
+    description: '강제 업데이트 여부',
+    example: false,
+  })
+  forceRedirect: boolean;
+}

--- a/src/config/version/version.controller.ts
+++ b/src/config/version/version.controller.ts
@@ -1,0 +1,44 @@
+import { Controller, Get, Put, Body } from '@nestjs/common';
+import { ApiOperation, ApiResponse, ApiTags, ApiBody } from '@nestjs/swagger';
+import { RedisService } from '@/config/redis/redis.service';
+import { VersionResponse } from './dto/version-response.dto';
+import { Role } from '@/types/enum';
+import { Roles } from '@auth/decorators';
+
+@ApiTags('Version')
+@Controller('/version')
+export class VersionManageController {
+  constructor(private readonly redisService: RedisService) {}
+
+  @Get('/store')
+  @ApiOperation({ summary: '스토어 버전 정보 조회' })
+  @ApiResponse({
+    status: 200,
+    description: '스토어 버전 정보 조회 성공',
+    type: VersionResponse,
+  })
+  async getStoreVersion(): Promise<VersionResponse> {
+    const version =
+      await this.redisService.getObject<VersionResponse>('version:store');
+    return version ?? { version: '1.0.0', forceRedirect: false };
+  }
+
+  @Roles(Role.ADMIN)
+  @Put('/store')
+  @ApiOperation({ summary: '스토어 버전 정보 갱신' })
+  @ApiBody({
+    type: VersionResponse,
+    description: '갱신할 버전 정보',
+  })
+  @ApiResponse({
+    status: 200,
+    description: '스토어 버전 정보 갱신 성공',
+    type: VersionResponse,
+  })
+  async updateStoreVersion(
+    @Body() versionData: VersionResponse,
+  ): Promise<VersionResponse> {
+    await this.redisService.setObject('version:store', versionData);
+    return versionData;
+  }
+}


### PR DESCRIPTION
## Summary
- Redis 객체 저장/조회 메서드 추가 (setObject, getObject)
- 스토어 버전 조회 API 구현 (GET /version/store)
- 스토어 버전 수정 API 구현 (PUT /version/store, 관리자 권한 필요)
- 타입 안전한 JSON 파싱 및 Swagger 문서화

## Test plan
- [ ] 버전 조회 API 테스트
- [ ] 버전 수정 API 테스트 (관리자 권한)
- [ ] Redis JSON 객체 저장/조회 테스트
- [ ] Swagger 문서 확인

🤖 Generated with [Claude Code](https://claude.ai/code)