### PR TITLE
feat: preference options 순서 및 deprecated 기능 구현

### DIFF
--- a/drizzle/0017_brave_silk_fever.sql
+++ b/drizzle/0017_brave_silk_fever.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "preference_options" ADD COLUMN "order" integer DEFAULT 0 NOT NULL;

--- a/drizzle/0018_calm_may_parker.sql
+++ b/drizzle/0018_calm_may_parker.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "preference_options" ADD COLUMN "deprecated" boolean DEFAULT true NOT NULL;

--- a/drizzle/data/initial_data.sql
+++ b/drizzle/data/initial_data.sql
@@ -1,0 +1,340 @@
+-- preference_types 데이터 삽입 (중복 시 무시)
+INSERT INTO preference_types (id, code, name, multi_select, maximum_choice_count, created_at, updated_at)
+SELECT gen_random_uuid(), 'PERSONALITY', '성격 유형', true, 1, NOW(), NOW()
+WHERE NOT EXISTS (SELECT 1 FROM preference_types WHERE code = 'PERSONALITY')
+UNION ALL
+SELECT gen_random_uuid(), 'DATING_STYLE', '연애 스타일', true, 3, NOW(), NOW()
+WHERE NOT EXISTS (SELECT 1 FROM preference_types WHERE code = 'DATING_STYLE')
+UNION ALL
+SELECT gen_random_uuid(), 'LIFESTYLE', '라이프스타일', true, 3, NOW(), NOW()
+WHERE NOT EXISTS (SELECT 1 FROM preference_types WHERE code = 'LIFESTYLE')
+UNION ALL
+SELECT gen_random_uuid(), 'DRINKING', '음주 선호도', false, 1, NOW(), NOW()
+WHERE NOT EXISTS (SELECT 1 FROM preference_types WHERE code = 'DRINKING')
+UNION ALL
+SELECT gen_random_uuid(), 'SMOKING', '흡연 선호도', false, 1, NOW(), NOW()
+WHERE NOT EXISTS (SELECT 1 FROM preference_types WHERE code = 'SMOKING')
+UNION ALL
+SELECT gen_random_uuid(), 'TATTOO', '문신 선호도', false, 1, NOW(), NOW()
+WHERE NOT EXISTS (SELECT 1 FROM preference_types WHERE code = 'TATTOO')
+UNION ALL
+SELECT gen_random_uuid(), 'INTEREST', '관심사', true, 5, NOW(), NOW()
+WHERE NOT EXISTS (SELECT 1 FROM preference_types WHERE code = 'INTEREST')
+UNION ALL
+SELECT gen_random_uuid(), 'MBTI', 'MBTI 유형', false, 1, NOW(), NOW()
+WHERE NOT EXISTS (SELECT 1 FROM preference_types WHERE code = 'MBTI')
+UNION ALL
+SELECT gen_random_uuid(), 'AGE_PREFERENCE', '선호 나이대', false, 1, NOW(), NOW()
+WHERE NOT EXISTS (SELECT 1 FROM preference_types WHERE code = 'AGE_PREFERENCE')
+UNION ALL
+SELECT gen_random_uuid(), 'MILITARY_STATUS_MALE', '군필 여부', false, 1, NOW(), NOW()
+WHERE NOT EXISTS (SELECT 1 FROM preference_types WHERE code = 'MILITARY_STATUS_MALE')
+UNION ALL
+SELECT gen_random_uuid(), 'MILITARY_PREFERENCE_FEMALE', '군필 여부 선호도', false, 1, NOW(), NOW()
+WHERE NOT EXISTS (SELECT 1 FROM preference_types WHERE code = 'MILITARY_PREFERENCE_FEMALE')
+UNION ALL
+SELECT gen_random_uuid(), 'personality', '성격', false, 1, NOW(), NOW()
+WHERE NOT EXISTS (SELECT 1 FROM preference_types WHERE code = 'personality');
+
+-- preference_options 데이터 삽입 - 성격 유형 (PERSONALITY)
+INSERT INTO preference_options (id, preference_type_id, value, display_name, "order", deprecated, created_at, updated_at)
+SELECT gen_random_uuid(), (SELECT id FROM preference_types WHERE code = 'PERSONALITY'), 'OUTGOING', '활발한 성격', 0, false, NOW(), NOW()
+WHERE NOT EXISTS (SELECT 1 FROM preference_options po JOIN preference_types pt ON po.preference_type_id = pt.id WHERE pt.code = 'PERSONALITY' AND po.value = 'OUTGOING')
+UNION ALL
+SELECT gen_random_uuid(), (SELECT id FROM preference_types WHERE code = 'PERSONALITY'), 'QUIET', '조용한 성격', 1, false, NOW(), NOW()
+WHERE NOT EXISTS (SELECT 1 FROM preference_options po JOIN preference_types pt ON po.preference_type_id = pt.id WHERE pt.code = 'PERSONALITY' AND po.value = 'QUIET')
+UNION ALL
+SELECT gen_random_uuid(), (SELECT id FROM preference_types WHERE code = 'PERSONALITY'), 'CARING', '배려심 많은 사람', 2, false, NOW(), NOW()
+WHERE NOT EXISTS (SELECT 1 FROM preference_options po JOIN preference_types pt ON po.preference_type_id = pt.id WHERE pt.code = 'PERSONALITY' AND po.value = 'CARING')
+UNION ALL
+SELECT gen_random_uuid(), (SELECT id FROM preference_types WHERE code = 'PERSONALITY'), 'LEADER', '리더십 있는 사람', 3, false, NOW(), NOW()
+WHERE NOT EXISTS (SELECT 1 FROM preference_options po JOIN preference_types pt ON po.preference_type_id = pt.id WHERE pt.code = 'PERSONALITY' AND po.value = 'LEADER')
+UNION ALL
+SELECT gen_random_uuid(), (SELECT id FROM preference_types WHERE code = 'PERSONALITY'), 'HUMOROUS', '유머 감각 있는 사람', 4, false, NOW(), NOW()
+WHERE NOT EXISTS (SELECT 1 FROM preference_options po JOIN preference_types pt ON po.preference_type_id = pt.id WHERE pt.code = 'PERSONALITY' AND po.value = 'HUMOROUS')
+UNION ALL
+SELECT gen_random_uuid(), (SELECT id FROM preference_types WHERE code = 'PERSONALITY'), 'EMOTIONAL', '감성적인 사람', 5, false, NOW(), NOW()
+WHERE NOT EXISTS (SELECT 1 FROM preference_options po JOIN preference_types pt ON po.preference_type_id = pt.id WHERE pt.code = 'PERSONALITY' AND po.value = 'EMOTIONAL')
+UNION ALL
+SELECT gen_random_uuid(), (SELECT id FROM preference_types WHERE code = 'PERSONALITY'), 'ADVENTUROUS', '모험을 즐기는 사람', 6, false, NOW(), NOW()
+WHERE NOT EXISTS (SELECT 1 FROM preference_options po JOIN preference_types pt ON po.preference_type_id = pt.id WHERE pt.code = 'PERSONALITY' AND po.value = 'ADVENTUROUS')
+UNION ALL
+SELECT gen_random_uuid(), (SELECT id FROM preference_types WHERE code = 'PERSONALITY'), 'PLANNER', '계획적인 스타일', 7, false, NOW(), NOW()
+WHERE NOT EXISTS (SELECT 1 FROM preference_options po JOIN preference_types pt ON po.preference_type_id = pt.id WHERE pt.code = 'PERSONALITY' AND po.value = 'PLANNER')
+UNION ALL
+SELECT gen_random_uuid(), (SELECT id FROM preference_types WHERE code = 'PERSONALITY'), 'SPONTANEOUS', '즉흥적인 스타일', 8, false, NOW(), NOW()
+WHERE NOT EXISTS (SELECT 1 FROM preference_options po JOIN preference_types pt ON po.preference_type_id = pt.id WHERE pt.code = 'PERSONALITY' AND po.value = 'SPONTANEOUS');
+
+-- preference_options 데이터 삽입 - 성격 (personality)
+INSERT INTO preference_options (id, preference_type_id, value, display_name, "order", deprecated, created_at, updated_at)
+SELECT gen_random_uuid(), (SELECT id FROM preference_types WHERE code = 'personality'), 'quiet', '조용한 성격', 0, false, NOW(), NOW()
+WHERE NOT EXISTS (SELECT 1 FROM preference_options po JOIN preference_types pt ON po.preference_type_id = pt.id WHERE pt.code = 'personality' AND po.value = 'quiet')
+UNION ALL
+SELECT gen_random_uuid(), (SELECT id FROM preference_types WHERE code = 'personality'), 'active', '활발한 성격', 1, false, NOW(), NOW()
+WHERE NOT EXISTS (SELECT 1 FROM preference_options po JOIN preference_types pt ON po.preference_type_id = pt.id WHERE pt.code = 'personality' AND po.value = 'active')
+UNION ALL
+SELECT gen_random_uuid(), (SELECT id FROM preference_types WHERE code = 'personality'), 'spontaneous', '즉흥적인 스타일', 2, false, NOW(), NOW()
+WHERE NOT EXISTS (SELECT 1 FROM preference_options po JOIN preference_types pt ON po.preference_type_id = pt.id WHERE pt.code = 'personality' AND po.value = 'spontaneous')
+UNION ALL
+SELECT gen_random_uuid(), (SELECT id FROM preference_types WHERE code = 'personality'), 'planned', '계획적인 스타일', 3, false, NOW(), NOW()
+WHERE NOT EXISTS (SELECT 1 FROM preference_options po JOIN preference_types pt ON po.preference_type_id = pt.id WHERE pt.code = 'personality' AND po.value = 'planned')
+UNION ALL
+SELECT gen_random_uuid(), (SELECT id FROM preference_types WHERE code = 'personality'), 'adventurous', '모험을 즐기는 사람', 4, false, NOW(), NOW()
+WHERE NOT EXISTS (SELECT 1 FROM preference_options po JOIN preference_types pt ON po.preference_type_id = pt.id WHERE pt.code = 'personality' AND po.value = 'adventurous')
+UNION ALL
+SELECT gen_random_uuid(), (SELECT id FROM preference_types WHERE code = 'personality'), 'emotional', '감성적인 사람', 5, false, NOW(), NOW()
+WHERE NOT EXISTS (SELECT 1 FROM preference_options po JOIN preference_types pt ON po.preference_type_id = pt.id WHERE pt.code = 'personality' AND po.value = 'emotional')
+UNION ALL
+SELECT gen_random_uuid(), (SELECT id FROM preference_types WHERE code = 'personality'), 'caring', '배려심 많은 사람', 6, false, NOW(), NOW()
+WHERE NOT EXISTS (SELECT 1 FROM preference_options po JOIN preference_types pt ON po.preference_type_id = pt.id WHERE pt.code = 'personality' AND po.value = 'caring')
+UNION ALL
+SELECT gen_random_uuid(), (SELECT id FROM preference_types WHERE code = 'personality'), 'humorous', '유머감각 있는 사람', 7, false, NOW(), NOW()
+WHERE NOT EXISTS (SELECT 1 FROM preference_options po JOIN preference_types pt ON po.preference_type_id = pt.id WHERE pt.code = 'personality' AND po.value = 'humorous')
+UNION ALL
+SELECT gen_random_uuid(), (SELECT id FROM preference_types WHERE code = 'personality'), 'leadership', '리더십 있는 사람', 8, false, NOW(), NOW()
+WHERE NOT EXISTS (SELECT 1 FROM preference_options po JOIN preference_types pt ON po.preference_type_id = pt.id WHERE pt.code = 'personality' AND po.value = 'leadership');
+
+-- preference_options 데이터 삽입 - 음주 선호도 (DRINKING)
+INSERT INTO preference_options (id, preference_type_id, value, display_name, "order", deprecated, created_at, updated_at)
+SELECT gen_random_uuid(), (SELECT id FROM preference_types WHERE code = 'DRINKING'), 'PREFER_NONE', '안마시면 좋겠음', 0, false, NOW(), NOW()
+WHERE NOT EXISTS (SELECT 1 FROM preference_options po JOIN preference_types pt ON po.preference_type_id = pt.id WHERE pt.code = 'DRINKING' AND po.value = 'PREFER_NONE')
+UNION ALL
+SELECT gen_random_uuid(), (SELECT id FROM preference_types WHERE code = 'DRINKING'), 'PREFER_OCCASIONALLY', '가끔마시면 좋겠음', 1, false, NOW(), NOW()
+WHERE NOT EXISTS (SELECT 1 FROM preference_options po JOIN preference_types pt ON po.preference_type_id = pt.id WHERE pt.code = 'DRINKING' AND po.value = 'PREFER_OCCASIONALLY')
+UNION ALL
+SELECT gen_random_uuid(), (SELECT id FROM preference_types WHERE code = 'DRINKING'), 'PREFER_MODERATE', '적당히 마시면 좋겠음', 2, false, NOW(), NOW()
+WHERE NOT EXISTS (SELECT 1 FROM preference_options po JOIN preference_types pt ON po.preference_type_id = pt.id WHERE pt.code = 'DRINKING' AND po.value = 'PREFER_MODERATE')
+UNION ALL
+SELECT gen_random_uuid(), (SELECT id FROM preference_types WHERE code = 'DRINKING'), 'OKAY', '마셔도 괜찮음', 3, false, NOW(), NOW()
+WHERE NOT EXISTS (SELECT 1 FROM preference_options po JOIN preference_types pt ON po.preference_type_id = pt.id WHERE pt.code = 'DRINKING' AND po.value = 'OKAY')
+UNION ALL
+SELECT gen_random_uuid(), (SELECT id FROM preference_types WHERE code = 'DRINKING'), 'FREQUENT_OKAY', '자주 마셔도 괜찮음', 4, false, NOW(), NOW()
+WHERE NOT EXISTS (SELECT 1 FROM preference_options po JOIN preference_types pt ON po.preference_type_id = pt.id WHERE pt.code = 'DRINKING' AND po.value = 'FREQUENT_OKAY')
+UNION ALL
+SELECT gen_random_uuid(), (SELECT id FROM preference_types WHERE code = 'DRINKING'), 'NEVER', '전혀 안마시지 않음', 0, false, NOW(), NOW()
+WHERE NOT EXISTS (SELECT 1 FROM preference_options po JOIN preference_types pt ON po.preference_type_id = pt.id WHERE pt.code = 'DRINKING' AND po.value = 'NEVER')
+UNION ALL
+SELECT gen_random_uuid(), (SELECT id FROM preference_types WHERE code = 'DRINKING'), 'RARELY', '거의 못마심', 1, false, NOW(), NOW()
+WHERE NOT EXISTS (SELECT 1 FROM preference_options po JOIN preference_types pt ON po.preference_type_id = pt.id WHERE pt.code = 'DRINKING' AND po.value = 'RARELY')
+UNION ALL
+SELECT gen_random_uuid(), (SELECT id FROM preference_types WHERE code = 'DRINKING'), 'MODERATE', '적당히 마심', 2, false, NOW(), NOW()
+WHERE NOT EXISTS (SELECT 1 FROM preference_options po JOIN preference_types pt ON po.preference_type_id = pt.id WHERE pt.code = 'DRINKING' AND po.value = 'MODERATE')
+UNION ALL
+SELECT gen_random_uuid(), (SELECT id FROM preference_types WHERE code = 'DRINKING'), 'FREQUENT', '자주 마심', 3, false, NOW(), NOW()
+WHERE NOT EXISTS (SELECT 1 FROM preference_options po JOIN preference_types pt ON po.preference_type_id = pt.id WHERE pt.code = 'DRINKING' AND po.value = 'FREQUENT')
+UNION ALL
+SELECT gen_random_uuid(), (SELECT id FROM preference_types WHERE code = 'DRINKING'), 'VERY_FREQUENT', '매우 즐겨 마심', 4, false, NOW(), NOW()
+WHERE NOT EXISTS (SELECT 1 FROM preference_options po JOIN preference_types pt ON po.preference_type_id = pt.id WHERE pt.code = 'DRINKING' AND po.value = 'VERY_FREQUENT');
+
+-- preference_options 데이터 삽입 - 흡연 선호도 (SMOKING)
+INSERT INTO preference_options (id, preference_type_id, value, display_name, "order", deprecated, created_at, updated_at)
+SELECT gen_random_uuid(), (SELECT id FROM preference_types WHERE code = 'SMOKING'), 'NON_SMOKER', '비흡연자', 0, false, NOW(), NOW()
+WHERE NOT EXISTS (SELECT 1 FROM preference_options po JOIN preference_types pt ON po.preference_type_id = pt.id WHERE pt.code = 'SMOKING' AND po.value = 'NON_SMOKER')
+UNION ALL
+SELECT gen_random_uuid(), (SELECT id FROM preference_types WHERE code = 'SMOKING'), 'E_CIGARETTE', '전자담배', 1, false, NOW(), NOW()
+WHERE NOT EXISTS (SELECT 1 FROM preference_options po JOIN preference_types pt ON po.preference_type_id = pt.id WHERE pt.code = 'SMOKING' AND po.value = 'E_CIGARETTE')
+UNION ALL
+SELECT gen_random_uuid(), (SELECT id FROM preference_types WHERE code = 'SMOKING'), 'NO_PREFERENCE', '상관없음', 1, false, NOW(), NOW()
+WHERE NOT EXISTS (SELECT 1 FROM preference_options po JOIN preference_types pt ON po.preference_type_id = pt.id WHERE pt.code = 'SMOKING' AND po.value = 'NO_PREFERENCE')
+UNION ALL
+SELECT gen_random_uuid(), (SELECT id FROM preference_types WHERE code = 'SMOKING'), 'SMOKER', '흡연자', 2, false, NOW(), NOW()
+WHERE NOT EXISTS (SELECT 1 FROM preference_options po JOIN preference_types pt ON po.preference_type_id = pt.id WHERE pt.code = 'SMOKING' AND po.value = 'SMOKER');
+
+-- preference_options 데이터 삽입 - 문신 선호도 (TATTOO)
+INSERT INTO preference_options (id, preference_type_id, value, display_name, "order", deprecated, created_at, updated_at)
+SELECT gen_random_uuid(), (SELECT id FROM preference_types WHERE code = 'TATTOO'), 'NONE_STRICT', '문신 X', 0, false, NOW(), NOW()
+WHERE NOT EXISTS (SELECT 1 FROM preference_options po JOIN preference_types pt ON po.preference_type_id = pt.id WHERE pt.code = 'TATTOO' AND po.value = 'NONE_STRICT')
+UNION ALL
+SELECT gen_random_uuid(), (SELECT id FROM preference_types WHERE code = 'TATTOO'), 'SMALL', '작은 문신', 1, false, NOW(), NOW()
+WHERE NOT EXISTS (SELECT 1 FROM preference_options po JOIN preference_types pt ON po.preference_type_id = pt.id WHERE pt.code = 'TATTOO' AND po.value = 'SMALL')
+UNION ALL
+SELECT gen_random_uuid(), (SELECT id FROM preference_types WHERE code = 'TATTOO'), 'NONE', '문신 없음', 1, false, NOW(), NOW()
+WHERE NOT EXISTS (SELECT 1 FROM preference_options po JOIN preference_types pt ON po.preference_type_id = pt.id WHERE pt.code = 'TATTOO' AND po.value = 'NONE')
+UNION ALL
+SELECT gen_random_uuid(), (SELECT id FROM preference_types WHERE code = 'TATTOO'), 'OKAY', '문신 O', 2, false, NOW(), NOW()
+WHERE NOT EXISTS (SELECT 1 FROM preference_options po JOIN preference_types pt ON po.preference_type_id = pt.id WHERE pt.code = 'TATTOO' AND po.value = 'OKAY');
+
+-- preference_options 데이터 삽입 - 군필 여부 (MILITARY_STATUS_MALE)
+INSERT INTO preference_options (id, preference_type_id, value, display_name, "order", deprecated, created_at, updated_at)
+SELECT gen_random_uuid(), (SELECT id FROM preference_types WHERE code = 'MILITARY_STATUS_MALE'), 'NOT_SERVED', '미필', 0, false, NOW(), NOW()
+WHERE NOT EXISTS (SELECT 1 FROM preference_options po JOIN preference_types pt ON po.preference_type_id = pt.id WHERE pt.code = 'MILITARY_STATUS_MALE' AND po.value = 'NOT_SERVED')
+UNION ALL
+SELECT gen_random_uuid(), (SELECT id FROM preference_types WHERE code = 'MILITARY_STATUS_MALE'), 'EXEMPTED', '면제', 1, false, NOW(), NOW()
+WHERE NOT EXISTS (SELECT 1 FROM preference_options po JOIN preference_types pt ON po.preference_type_id = pt.id WHERE pt.code = 'MILITARY_STATUS_MALE' AND po.value = 'EXEMPTED')
+UNION ALL
+SELECT gen_random_uuid(), (SELECT id FROM preference_types WHERE code = 'MILITARY_STATUS_MALE'), 'SERVED', '군필', 2, false, NOW(), NOW()
+WHERE NOT EXISTS (SELECT 1 FROM preference_options po JOIN preference_types pt ON po.preference_type_id = pt.id WHERE pt.code = 'MILITARY_STATUS_MALE' AND po.value = 'SERVED');
+
+-- preference_options 데이터 삽입 - 군필 여부 선호도 (MILITARY_PREFERENCE_FEMALE)
+INSERT INTO preference_options (id, preference_type_id, value, display_name, "order", deprecated, created_at, updated_at)
+SELECT gen_random_uuid(), (SELECT id FROM preference_types WHERE code = 'MILITARY_PREFERENCE_FEMALE'), 'NOT_SERVED', '미필', 0, false, NOW(), NOW()
+WHERE NOT EXISTS (SELECT 1 FROM preference_options po JOIN preference_types pt ON po.preference_type_id = pt.id WHERE pt.code = 'MILITARY_PREFERENCE_FEMALE' AND po.value = 'NOT_SERVED')
+UNION ALL
+SELECT gen_random_uuid(), (SELECT id FROM preference_types WHERE code = 'MILITARY_PREFERENCE_FEMALE'), 'NO_PREFERENCE', '상관없음', 1, false, NOW(), NOW()
+WHERE NOT EXISTS (SELECT 1 FROM preference_options po JOIN preference_types pt ON po.preference_type_id = pt.id WHERE pt.code = 'MILITARY_PREFERENCE_FEMALE' AND po.value = 'NO_PREFERENCE')
+UNION ALL
+SELECT gen_random_uuid(), (SELECT id FROM preference_types WHERE code = 'MILITARY_PREFERENCE_FEMALE'), 'SERVED', '군필', 2, false, NOW(), NOW()
+WHERE NOT EXISTS (SELECT 1 FROM preference_options po JOIN preference_types pt ON po.preference_type_id = pt.id WHERE pt.code = 'MILITARY_PREFERENCE_FEMALE' AND po.value = 'SERVED');
+
+-- preference_options 데이터 삽입 - 연애 스타일 (DATING_STYLE)
+INSERT INTO preference_options (id, preference_type_id, value, display_name, "order", deprecated, created_at, updated_at)
+SELECT gen_random_uuid(), (SELECT id FROM preference_types WHERE code = 'DATING_STYLE'), 'PROACTIVE', '적극적인 스타일', 0, false, NOW(), NOW()
+WHERE NOT EXISTS (SELECT 1 FROM preference_options po JOIN preference_types pt ON po.preference_type_id = pt.id WHERE pt.code = 'DATING_STYLE' AND po.value = 'PROACTIVE')
+UNION ALL
+SELECT gen_random_uuid(), (SELECT id FROM preference_types WHERE code = 'DATING_STYLE'), 'AFFECTIONATE', '다정다감한 스타일', 1, false, NOW(), NOW()
+WHERE NOT EXISTS (SELECT 1 FROM preference_options po JOIN preference_types pt ON po.preference_type_id = pt.id WHERE pt.code = 'DATING_STYLE' AND po.value = 'AFFECTIONATE')
+UNION ALL
+SELECT gen_random_uuid(), (SELECT id FROM preference_types WHERE code = 'DATING_STYLE'), 'FRIENDLY', '친구처럼 지내는 스타일', 2, false, NOW(), NOW()
+WHERE NOT EXISTS (SELECT 1 FROM preference_options po JOIN preference_types pt ON po.preference_type_id = pt.id WHERE pt.code = 'DATING_STYLE' AND po.value = 'FRIENDLY')
+UNION ALL
+SELECT gen_random_uuid(), (SELECT id FROM preference_types WHERE code = 'DATING_STYLE'), 'TSUNDERE', '츤데레 스타일', 3, false, NOW(), NOW()
+WHERE NOT EXISTS (SELECT 1 FROM preference_options po JOIN preference_types pt ON po.preference_type_id = pt.id WHERE pt.code = 'DATING_STYLE' AND po.value = 'TSUNDERE')
+UNION ALL
+SELECT gen_random_uuid(), (SELECT id FROM preference_types WHERE code = 'DATING_STYLE'), 'ATTENTIVE', '상대방을 많이 챙기는 스타일', 4, false, NOW(), NOW()
+WHERE NOT EXISTS (SELECT 1 FROM preference_options po JOIN preference_types pt ON po.preference_type_id = pt.id WHERE pt.code = 'DATING_STYLE' AND po.value = 'ATTENTIVE')
+UNION ALL
+SELECT gen_random_uuid(), (SELECT id FROM preference_types WHERE code = 'DATING_STYLE'), 'RESERVED_BUT_CARING', '표현을 잘 안 하지만 속은 다정한 스타일', 5, false, NOW(), NOW()
+WHERE NOT EXISTS (SELECT 1 FROM preference_options po JOIN preference_types pt ON po.preference_type_id = pt.id WHERE pt.code = 'DATING_STYLE' AND po.value = 'RESERVED_BUT_CARING')
+UNION ALL
+SELECT gen_random_uuid(), (SELECT id FROM preference_types WHERE code = 'DATING_STYLE'), 'FREE_SPIRITED', '자유로운 연애를 선호하는 스타일', 6, false, NOW(), NOW()
+WHERE NOT EXISTS (SELECT 1 FROM preference_options po JOIN preference_types pt ON po.preference_type_id = pt.id WHERE pt.code = 'DATING_STYLE' AND po.value = 'FREE_SPIRITED')
+UNION ALL
+SELECT gen_random_uuid(), (SELECT id FROM preference_types WHERE code = 'DATING_STYLE'), 'FREQUENT_CONTACT', '자주 연락하는 걸 선호하는 스타일', 7, false, NOW(), NOW()
+WHERE NOT EXISTS (SELECT 1 FROM preference_options po JOIN preference_types pt ON po.preference_type_id = pt.id WHERE pt.code = 'DATING_STYLE' AND po.value = 'FREQUENT_CONTACT');
+
+-- preference_options 데이터 삽입 - 라이프스타일 (LIFESTYLE)
+INSERT INTO preference_options (id, preference_type_id, value, display_name, "order", deprecated, created_at, updated_at)
+SELECT gen_random_uuid(), (SELECT id FROM preference_types WHERE code = 'LIFESTYLE'), 'MORNING_PERSON', '아침형 인간', 0, false, NOW(), NOW()
+WHERE NOT EXISTS (SELECT 1 FROM preference_options po JOIN preference_types pt ON po.preference_type_id = pt.id WHERE pt.code = 'LIFESTYLE' AND po.value = 'MORNING_PERSON')
+UNION ALL
+SELECT gen_random_uuid(), (SELECT id FROM preference_types WHERE code = 'LIFESTYLE'), 'NIGHT_PERSON', '밤형 인간', 1, false, NOW(), NOW()
+WHERE NOT EXISTS (SELECT 1 FROM preference_options po JOIN preference_types pt ON po.preference_type_id = pt.id WHERE pt.code = 'LIFESTYLE' AND po.value = 'NIGHT_PERSON')
+UNION ALL
+SELECT gen_random_uuid(), (SELECT id FROM preference_types WHERE code = 'LIFESTYLE'), 'HOMEBODY', '집순이 / 집돌이', 2, false, NOW(), NOW()
+WHERE NOT EXISTS (SELECT 1 FROM preference_options po JOIN preference_types pt ON po.preference_type_id = pt.id WHERE pt.code = 'LIFESTYLE' AND po.value = 'HOMEBODY')
+UNION ALL
+SELECT gen_random_uuid(), (SELECT id FROM preference_types WHERE code = 'LIFESTYLE'), 'TRAVELER', '여행을 자주 다니는 편', 3, false, NOW(), NOW()
+WHERE NOT EXISTS (SELECT 1 FROM preference_options po JOIN preference_types pt ON po.preference_type_id = pt.id WHERE pt.code = 'LIFESTYLE' AND po.value = 'TRAVELER')
+UNION ALL
+SELECT gen_random_uuid(), (SELECT id FROM preference_types WHERE code = 'LIFESTYLE'), 'ACTIVE', '운동을 즐기는 편', 4, false, NOW(), NOW()
+WHERE NOT EXISTS (SELECT 1 FROM preference_options po JOIN preference_types pt ON po.preference_type_id = pt.id WHERE pt.code = 'LIFESTYLE' AND po.value = 'ACTIVE')
+UNION ALL
+SELECT gen_random_uuid(), (SELECT id FROM preference_types WHERE code = 'LIFESTYLE'), 'GAMER', '게임을 자주 하는 편', 5, false, NOW(), NOW()
+WHERE NOT EXISTS (SELECT 1 FROM preference_options po JOIN preference_types pt ON po.preference_type_id = pt.id WHERE pt.code = 'LIFESTYLE' AND po.value = 'GAMER')
+UNION ALL
+SELECT gen_random_uuid(), (SELECT id FROM preference_types WHERE code = 'LIFESTYLE'), 'CAFE_LOVER', '카페에서 노는 걸 좋아함', 6, false, NOW(), NOW()
+WHERE NOT EXISTS (SELECT 1 FROM preference_options po JOIN preference_types pt ON po.preference_type_id = pt.id WHERE pt.code = 'LIFESTYLE' AND po.value = 'CAFE_LOVER')
+UNION ALL
+SELECT gen_random_uuid(), (SELECT id FROM preference_types WHERE code = 'LIFESTYLE'), 'ACTIVITY_LOVER', '액티비티 활동을 좋아함', 7, false, NOW(), NOW()
+WHERE NOT EXISTS (SELECT 1 FROM preference_options po JOIN preference_types pt ON po.preference_type_id = pt.id WHERE pt.code = 'LIFESTYLE' AND po.value = 'ACTIVITY_LOVER');
+
+-- preference_options 데이터 삽입 - 관심사 (INTEREST)
+INSERT INTO preference_options (id, preference_type_id, value, display_name, image_url, "order", deprecated, created_at, updated_at)
+SELECT gen_random_uuid(), (SELECT id FROM preference_types WHERE code = 'INTEREST'), 'MOVIES', '영화', 'https://sometimes-resources.s3.ap-northeast-2.amazonaws.com/icons/movie.png', 0, false, NOW(), NOW()
+WHERE NOT EXISTS (SELECT 1 FROM preference_options po JOIN preference_types pt ON po.preference_type_id = pt.id WHERE pt.code = 'INTEREST' AND po.value = 'MOVIES')
+UNION ALL
+SELECT gen_random_uuid(), (SELECT id FROM preference_types WHERE code = 'INTEREST'), 'MUSIC', '음악', 'https://sometimes-resources.s3.ap-northeast-2.amazonaws.com/icons/music.png', 1, false, NOW(), NOW()
+WHERE NOT EXISTS (SELECT 1 FROM preference_options po JOIN preference_types pt ON po.preference_type_id = pt.id WHERE pt.code = 'INTEREST' AND po.value = 'MUSIC')
+UNION ALL
+SELECT gen_random_uuid(), (SELECT id FROM preference_types WHERE code = 'INTEREST'), 'READING', '독서', 'https://sometimes-resources.s3.ap-northeast-2.amazonaws.com/icons/reading.png', 2, false, NOW(), NOW()
+WHERE NOT EXISTS (SELECT 1 FROM preference_options po JOIN preference_types pt ON po.preference_type_id = pt.id WHERE pt.code = 'INTEREST' AND po.value = 'READING')
+UNION ALL
+SELECT gen_random_uuid(), (SELECT id FROM preference_types WHERE code = 'INTEREST'), 'GAMING', '게임', 'https://sometimes-resources.s3.ap-northeast-2.amazonaws.com/icons/gaming.png', 3, false, NOW(), NOW()
+WHERE NOT EXISTS (SELECT 1 FROM preference_options po JOIN preference_types pt ON po.preference_type_id = pt.id WHERE pt.code = 'INTEREST' AND po.value = 'GAMING')
+UNION ALL
+SELECT gen_random_uuid(), (SELECT id FROM preference_types WHERE code = 'INTEREST'), 'SPORTS', '운동', 'https://sometimes-resources.s3.ap-northeast-2.amazonaws.com/icons/exercise.png', 4, false, NOW(), NOW()
+WHERE NOT EXISTS (SELECT 1 FROM preference_options po JOIN preference_types pt ON po.preference_type_id = pt.id WHERE pt.code = 'INTEREST' AND po.value = 'SPORTS')
+UNION ALL
+SELECT gen_random_uuid(), (SELECT id FROM preference_types WHERE code = 'INTEREST'), 'COOKING', '요리', 'https://sometimes-resources.s3.ap-northeast-2.amazonaws.com/icons/cooking.png', 5, false, NOW(), NOW()
+WHERE NOT EXISTS (SELECT 1 FROM preference_options po JOIN preference_types pt ON po.preference_type_id = pt.id WHERE pt.code = 'INTEREST' AND po.value = 'COOKING')
+UNION ALL
+SELECT gen_random_uuid(), (SELECT id FROM preference_types WHERE code = 'INTEREST'), 'TRAVEL', '여행', 'https://sometimes-resources.s3.ap-northeast-2.amazonaws.com/icons/travel.png', 6, false, NOW(), NOW()
+WHERE NOT EXISTS (SELECT 1 FROM preference_options po JOIN preference_types pt ON po.preference_type_id = pt.id WHERE pt.code = 'INTEREST' AND po.value = 'TRAVEL')
+UNION ALL
+SELECT gen_random_uuid(), (SELECT id FROM preference_types WHERE code = 'INTEREST'), 'PHOTOGRAPHY', '사진', 'https://sometimes-resources.s3.ap-northeast-2.amazonaws.com/icons/capture.png', 7, false, NOW(), NOW()
+WHERE NOT EXISTS (SELECT 1 FROM preference_options po JOIN preference_types pt ON po.preference_type_id = pt.id WHERE pt.code = 'INTEREST' AND po.value = 'PHOTOGRAPHY')
+UNION ALL
+SELECT gen_random_uuid(), (SELECT id FROM preference_types WHERE code = 'INTEREST'), 'FASHION', '패션', 'https://sometimes-resources.s3.ap-northeast-2.amazonaws.com/icons/fashion.png', 8, false, NOW(), NOW()
+WHERE NOT EXISTS (SELECT 1 FROM preference_options po JOIN preference_types pt ON po.preference_type_id = pt.id WHERE pt.code = 'INTEREST' AND po.value = 'FASHION')
+UNION ALL
+SELECT gen_random_uuid(), (SELECT id FROM preference_types WHERE code = 'INTEREST'), 'CAFE', '카페', 'https://sometimes-resources.s3.ap-northeast-2.amazonaws.com/icons/cafe.png', 9, false, NOW(), NOW()
+WHERE NOT EXISTS (SELECT 1 FROM preference_options po JOIN preference_types pt ON po.preference_type_id = pt.id WHERE pt.code = 'INTEREST' AND po.value = 'CAFE')
+UNION ALL
+SELECT gen_random_uuid(), (SELECT id FROM preference_types WHERE code = 'INTEREST'), 'PERFORMANCE', '공연', 'https://sometimes-resources.s3.ap-northeast-2.amazonaws.com/icons/festival.png', 10, false, NOW(), NOW()
+WHERE NOT EXISTS (SELECT 1 FROM preference_options po JOIN preference_types pt ON po.preference_type_id = pt.id WHERE pt.code = 'INTEREST' AND po.value = 'PERFORMANCE')
+UNION ALL
+SELECT gen_random_uuid(), (SELECT id FROM preference_types WHERE code = 'INTEREST'), 'EXHIBITION', '전시', 'https://sometimes-resources.s3.ap-northeast-2.amazonaws.com/icons/pictures.png', 11, false, NOW(), NOW()
+WHERE NOT EXISTS (SELECT 1 FROM preference_options po JOIN preference_types pt ON po.preference_type_id = pt.id WHERE pt.code = 'INTEREST' AND po.value = 'EXHIBITION')
+UNION ALL
+SELECT gen_random_uuid(), (SELECT id FROM preference_types WHERE code = 'INTEREST'), 'PETS', '반려동물', 'https://sometimes-resources.s3.ap-northeast-2.amazonaws.com/icons/pet.png', 12, false, NOW(), NOW()
+WHERE NOT EXISTS (SELECT 1 FROM preference_options po JOIN preference_types pt ON po.preference_type_id = pt.id WHERE pt.code = 'INTEREST' AND po.value = 'PETS')
+UNION ALL
+SELECT gen_random_uuid(), (SELECT id FROM preference_types WHERE code = 'INTEREST'), 'HIKING', '등산', 'https://sometimes-resources.s3.ap-northeast-2.amazonaws.com/icons/hiking.png', 13, false, NOW(), NOW()
+WHERE NOT EXISTS (SELECT 1 FROM preference_options po JOIN preference_types pt ON po.preference_type_id = pt.id WHERE pt.code = 'INTEREST' AND po.value = 'HIKING')
+UNION ALL
+SELECT gen_random_uuid(), (SELECT id FROM preference_types WHERE code = 'INTEREST'), 'CYCLING', '자전거', 'https://sometimes-resources.s3.ap-northeast-2.amazonaws.com/icons/sports.png', 14, false, NOW(), NOW()
+WHERE NOT EXISTS (SELECT 1 FROM preference_options po JOIN preference_types pt ON po.preference_type_id = pt.id WHERE pt.code = 'INTEREST' AND po.value = 'CYCLING');
+
+-- preference_options 데이터 삽입 - MBTI 유형 (MBTI)
+INSERT INTO preference_options (id, preference_type_id, value, display_name, "order", deprecated, created_at, updated_at)
+SELECT gen_random_uuid(), (SELECT id FROM preference_types WHERE code = 'MBTI'), 'INTJ', 'INTJ', 0, false, NOW(), NOW()
+WHERE NOT EXISTS (SELECT 1 FROM preference_options po JOIN preference_types pt ON po.preference_type_id = pt.id WHERE pt.code = 'MBTI' AND po.value = 'INTJ')
+UNION ALL
+SELECT gen_random_uuid(), (SELECT id FROM preference_types WHERE code = 'MBTI'), 'INTP', 'INTP', 1, false, NOW(), NOW()
+WHERE NOT EXISTS (SELECT 1 FROM preference_options po JOIN preference_types pt ON po.preference_type_id = pt.id WHERE pt.code = 'MBTI' AND po.value = 'INTP')
+UNION ALL
+SELECT gen_random_uuid(), (SELECT id FROM preference_types WHERE code = 'MBTI'), 'ENTJ', 'ENTJ', 2, false, NOW(), NOW()
+WHERE NOT EXISTS (SELECT 1 FROM preference_options po JOIN preference_types pt ON po.preference_type_id = pt.id WHERE pt.code = 'MBTI' AND po.value = 'ENTJ')
+UNION ALL
+SELECT gen_random_uuid(), (SELECT id FROM preference_types WHERE code = 'MBTI'), 'ENTP', 'ENTP', 3, false, NOW(), NOW()
+WHERE NOT EXISTS (SELECT 1 FROM preference_options po JOIN preference_types pt ON po.preference_type_id = pt.id WHERE pt.code = 'MBTI' AND po.value = 'ENTP')
+UNION ALL
+SELECT gen_random_uuid(), (SELECT id FROM preference_types WHERE code = 'MBTI'), 'INFJ', 'INFJ', 4, false, NOW(), NOW()
+WHERE NOT EXISTS (SELECT 1 FROM preference_options po JOIN preference_types pt ON po.preference_type_id = pt.id WHERE pt.code = 'MBTI' AND po.value = 'INFJ')
+UNION ALL
+SELECT gen_random_uuid(), (SELECT id FROM preference_types WHERE code = 'MBTI'), 'INFP', 'INFP', 5, false, NOW(), NOW()
+WHERE NOT EXISTS (SELECT 1 FROM preference_options po JOIN preference_types pt ON po.preference_type_id = pt.id WHERE pt.code = 'MBTI' AND po.value = 'INFP')
+UNION ALL
+SELECT gen_random_uuid(), (SELECT id FROM preference_types WHERE code = 'MBTI'), 'ENFJ', 'ENFJ', 6, false, NOW(), NOW()
+WHERE NOT EXISTS (SELECT 1 FROM preference_options po JOIN preference_types pt ON po.preference_type_id = pt.id WHERE pt.code = 'MBTI' AND po.value = 'ENFJ')
+UNION ALL
+SELECT gen_random_uuid(), (SELECT id FROM preference_types WHERE code = 'MBTI'), 'ENFP', 'ENFP', 7, false, NOW(), NOW()
+WHERE NOT EXISTS (SELECT 1 FROM preference_options po JOIN preference_types pt ON po.preference_type_id = pt.id WHERE pt.code = 'MBTI' AND po.value = 'ENFP')
+UNION ALL
+SELECT gen_random_uuid(), (SELECT id FROM preference_types WHERE code = 'MBTI'), 'ISTJ', 'ISTJ', 8, false, NOW(), NOW()
+WHERE NOT EXISTS (SELECT 1 FROM preference_options po JOIN preference_types pt ON po.preference_type_id = pt.id WHERE pt.code = 'MBTI' AND po.value = 'ISTJ')
+UNION ALL
+SELECT gen_random_uuid(), (SELECT id FROM preference_types WHERE code = 'MBTI'), 'ISFJ', 'ISFJ', 9, false, NOW(), NOW()
+WHERE NOT EXISTS (SELECT 1 FROM preference_options po JOIN preference_types pt ON po.preference_type_id = pt.id WHERE pt.code = 'MBTI' AND po.value = 'ISFJ')
+UNION ALL
+SELECT gen_random_uuid(), (SELECT id FROM preference_types WHERE code = 'MBTI'), 'ESTJ', 'ESTJ', 10, false, NOW(), NOW()
+WHERE NOT EXISTS (SELECT 1 FROM preference_options po JOIN preference_types pt ON po.preference_type_id = pt.id WHERE pt.code = 'MBTI' AND po.value = 'ESTJ')
+UNION ALL
+SELECT gen_random_uuid(), (SELECT id FROM preference_types WHERE code = 'MBTI'), 'ESFJ', 'ESFJ', 11, false, NOW(), NOW()
+WHERE NOT EXISTS (SELECT 1 FROM preference_options po JOIN preference_types pt ON po.preference_type_id = pt.id WHERE pt.code = 'MBTI' AND po.value = 'ESFJ')
+UNION ALL
+SELECT gen_random_uuid(), (SELECT id FROM preference_types WHERE code = 'MBTI'), 'ISTP', 'ISTP', 12, false, NOW(), NOW()
+WHERE NOT EXISTS (SELECT 1 FROM preference_options po JOIN preference_types pt ON po.preference_type_id = pt.id WHERE pt.code = 'MBTI' AND po.value = 'ISTP')
+UNION ALL
+SELECT gen_random_uuid(), (SELECT id FROM preference_types WHERE code = 'MBTI'), 'ISFP', 'ISFP', 13, false, NOW(), NOW()
+WHERE NOT EXISTS (SELECT 1 FROM preference_options po JOIN preference_types pt ON po.preference_type_id = pt.id WHERE pt.code = 'MBTI' AND po.value = 'ISFP')
+UNION ALL
+SELECT gen_random_uuid(), (SELECT id FROM preference_types WHERE code = 'MBTI'), 'ESTP', 'ESTP', 14, false, NOW(), NOW()
+WHERE NOT EXISTS (SELECT 1 FROM preference_options po JOIN preference_types pt ON po.preference_type_id = pt.id WHERE pt.code = 'MBTI' AND po.value = 'ESTP')
+UNION ALL
+SELECT gen_random_uuid(), (SELECT id FROM preference_types WHERE code = 'MBTI'), 'ESFP', 'ESFP', 15, false, NOW(), NOW()
+WHERE NOT EXISTS (SELECT 1 FROM preference_options po JOIN preference_types pt ON po.preference_type_id = pt.id WHERE pt.code = 'MBTI' AND po.value = 'ESFP');
+
+-- preference_options 데이터 삽입 - 선호 나이대 (AGE_PREFERENCE)
+INSERT INTO preference_options (id, preference_type_id, value, display_name, "order", deprecated, created_at, updated_at)
+SELECT gen_random_uuid(), (SELECT id FROM preference_types WHERE code = 'AGE_PREFERENCE'), 'OLDER', '연상', 0, false, NOW(), NOW()
+WHERE NOT EXISTS (SELECT 1 FROM preference_options po JOIN preference_types pt ON po.preference_type_id = pt.id WHERE pt.code = 'AGE_PREFERENCE' AND po.value = 'OLDER')
+UNION ALL
+SELECT gen_random_uuid(), (SELECT id FROM preference_types WHERE code = 'AGE_PREFERENCE'), 'YOUNGER', '연하', 1, false, NOW(), NOW()
+WHERE NOT EXISTS (SELECT 1 FROM preference_options po JOIN preference_types pt ON po.preference_type_id = pt.id WHERE pt.code = 'AGE_PREFERENCE' AND po.value = 'YOUNGER')
+UNION ALL
+SELECT gen_random_uuid(), (SELECT id FROM preference_types WHERE code = 'AGE_PREFERENCE'), 'SAME_AGE', '동갑', 2, false, NOW(), NOW()
+WHERE NOT EXISTS (SELECT 1 FROM preference_options po JOIN preference_types pt ON po.preference_type_id = pt.id WHERE pt.code = 'AGE_PREFERENCE' AND po.value = 'SAME_AGE')
+UNION ALL
+SELECT gen_random_uuid(), (SELECT id FROM preference_types WHERE code = 'AGE_PREFERENCE'), 'NO_PREFERENCE', '상관없음', 3, false, NOW(), NOW()
+WHERE NOT EXISTS (SELECT 1 FROM preference_options po JOIN preference_types pt ON po.preference_type_id = pt.id WHERE pt.code = 'AGE_PREFERENCE' AND po.value = 'NO_PREFERENCE');

--- a/drizzle/data/preference_options.sql
+++ b/drizzle/data/preference_options.sql
@@ -1,0 +1,77 @@
+-- 음주 선호도 - 선호도 옵션
+UPDATE preference_options SET "order" = 0, deprecated = false 
+WHERE value = 'PREFER_NONE' AND preference_type_id = (SELECT id FROM preference_types WHERE code = 'DRINKING');
+
+UPDATE preference_options SET "order" = 1, deprecated = false 
+WHERE value = 'PREFER_OCCASIONALLY' AND preference_type_id = (SELECT id FROM preference_types WHERE code = 'DRINKING');
+
+UPDATE preference_options SET "order" = 2, deprecated = false 
+WHERE value = 'PREFER_MODERATE' AND preference_type_id = (SELECT id FROM preference_types WHERE code = 'DRINKING');
+
+UPDATE preference_options SET "order" = 3, deprecated = false 
+WHERE value = 'OKAY' AND preference_type_id = (SELECT id FROM preference_types WHERE code = 'DRINKING');
+
+UPDATE preference_options SET "order" = 4, deprecated = false 
+WHERE value = 'FREQUENT_OKAY' AND preference_type_id = (SELECT id FROM preference_types WHERE code = 'DRINKING');
+
+-- 음주 선호도 - 본인 상태
+UPDATE preference_options SET "order" = 0, deprecated = false 
+WHERE value = 'NEVER' AND preference_type_id = (SELECT id FROM preference_types WHERE code = 'DRINKING');
+
+UPDATE preference_options SET "order" = 1, deprecated = false 
+WHERE value = 'RARELY' AND preference_type_id = (SELECT id FROM preference_types WHERE code = 'DRINKING');
+
+UPDATE preference_options SET "order" = 2, deprecated = false 
+WHERE value = 'MODERATE' AND preference_type_id = (SELECT id FROM preference_types WHERE code = 'DRINKING');
+
+UPDATE preference_options SET "order" = 3, deprecated = false 
+WHERE value = 'FREQUENT' AND preference_type_id = (SELECT id FROM preference_types WHERE code = 'DRINKING');
+
+UPDATE preference_options SET "order" = 4, deprecated = false 
+WHERE value = 'VERY_FREQUENT' AND preference_type_id = (SELECT id FROM preference_types WHERE code = 'DRINKING');
+
+-- 흡연 선호도
+UPDATE preference_options SET "order" = 0, deprecated = false 
+WHERE value = 'NON_SMOKER' AND preference_type_id = (SELECT id FROM preference_types WHERE code = 'SMOKING');
+
+UPDATE preference_options SET "order" = 1, deprecated = false 
+WHERE value = 'E_CIGARETTE' AND preference_type_id = (SELECT id FROM preference_types WHERE code = 'SMOKING');
+
+UPDATE preference_options SET "order" = 1, deprecated = false 
+WHERE value = 'NO_PREFERENCE' AND preference_type_id = (SELECT id FROM preference_types WHERE code = 'SMOKING');
+
+UPDATE preference_options SET "order" = 2, deprecated = false 
+WHERE value = 'SMOKER' AND preference_type_id = (SELECT id FROM preference_types WHERE code = 'SMOKING');
+
+-- 문신 선호도
+UPDATE preference_options SET "order" = 0, deprecated = false 
+WHERE value = 'NONE_STRICT' AND preference_type_id = (SELECT id FROM preference_types WHERE code = 'TATTOO');
+
+UPDATE preference_options SET "order" = 1, deprecated = false 
+WHERE value = 'SMALL' AND preference_type_id = (SELECT id FROM preference_types WHERE code = 'TATTOO');
+
+UPDATE preference_options SET "order" = 1, deprecated = false 
+WHERE value = 'NONE' AND preference_type_id = (SELECT id FROM preference_types WHERE code = 'TATTOO');
+
+UPDATE preference_options SET "order" = 2, deprecated = false 
+WHERE value = 'OKAY' AND preference_type_id = (SELECT id FROM preference_types WHERE code = 'TATTOO');
+
+-- 군필 여부
+UPDATE preference_options SET "order" = 0, deprecated = false 
+WHERE value = 'NOT_SERVED' AND preference_type_id = (SELECT id FROM preference_types WHERE code = 'MILITARY_STATUS_MALE');
+
+UPDATE preference_options SET "order" = 1, deprecated = false 
+WHERE value = 'EXEMPTED' AND preference_type_id = (SELECT id FROM preference_types WHERE code = 'MILITARY_STATUS_MALE');
+
+UPDATE preference_options SET "order" = 2, deprecated = false 
+WHERE value = 'SERVED' AND preference_type_id = (SELECT id FROM preference_types WHERE code = 'MILITARY_STATUS_MALE');
+
+-- 군필 여부 선호도
+UPDATE preference_options SET "order" = 0, deprecated = false 
+WHERE value = 'NOT_SERVED' AND preference_type_id = (SELECT id FROM preference_types WHERE code = 'MILITARY_PREFERENCE_FEMALE');
+
+UPDATE preference_options SET "order" = 1, deprecated = false 
+WHERE value = 'NO_PREFERENCE' AND preference_type_id = (SELECT id FROM preference_types WHERE code = 'MILITARY_PREFERENCE_FEMALE');
+
+UPDATE preference_options SET "order" = 2, deprecated = false 
+WHERE value = 'SERVED' AND preference_type_id = (SELECT id FROM preference_types WHERE code = 'MILITARY_PREFERENCE_FEMALE');

--- a/drizzle/meta/0017_snapshot.json
+++ b/drizzle/meta/0017_snapshot.json
@@ -1,0 +1,2502 @@
+{
+  "id": "a04e4a49-3299-44b4-9a44-d00933e34d1b",
+  "prevId": "4a4571b0-1c49-4a86-850d-53945147e11a",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.additional_preferences": {
+      "name": "additional_preferences",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(128)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "good_mbti": {
+          "name": "good_mbti",
+          "type": "varchar(4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bad_mbti": {
+          "name": "bad_mbti",
+          "type": "varchar(4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "profile_id": {
+          "name": "profile_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "additional_preferences_profile_id_profiles_id_fk": {
+          "name": "additional_preferences_profile_id_profiles_id_fk",
+          "tableFrom": "additional_preferences",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "additional_preferences_profile_id_unique": {
+          "name": "additional_preferences_profile_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "profile_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.article_categories": {
+      "name": "article_categories",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(128)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "emoji_url": {
+          "name": "emoji_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code": {
+          "name": "code",
+          "type": "varchar(15)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.articles": {
+      "name": "articles",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(128)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(30)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category_id": {
+          "name": "category_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "anonymous": {
+          "name": "anonymous",
+          "type": "varchar(15)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "like_count": {
+          "name": "like_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "blinded_at": {
+          "name": "blinded_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "read_count": {
+          "name": "read_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "articles_author_id_users_id_fk": {
+          "name": "articles_author_id_users_id_fk",
+          "tableFrom": "articles",
+          "tableTo": "users",
+          "columnsFrom": [
+            "author_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "articles_category_id_article_categories_id_fk": {
+          "name": "articles_category_id_article_categories_id_fk",
+          "tableFrom": "articles",
+          "tableTo": "article_categories",
+          "columnsFrom": [
+            "category_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.comments": {
+      "name": "comments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(128)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "article_id": {
+          "name": "article_id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content": {
+          "name": "content",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "nickname": {
+          "name": "nickname",
+          "type": "varchar(15)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "blinded_at": {
+          "name": "blinded_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "comments_author_id_users_id_fk": {
+          "name": "comments_author_id_users_id_fk",
+          "tableFrom": "comments",
+          "tableTo": "users",
+          "columnsFrom": [
+            "author_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "comments_article_id_articles_id_fk": {
+          "name": "comments_article_id_articles_id_fk",
+          "tableFrom": "comments",
+          "tableTo": "articles",
+          "columnsFrom": [
+            "article_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "comments_parent_id_comments_id_fk": {
+          "name": "comments_parent_id_comments_id_fk",
+          "tableFrom": "comments",
+          "tableTo": "comments",
+          "columnsFrom": [
+            "parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.gem_daily_stats": {
+      "name": "gem_daily_stats",
+      "schema": "",
+      "columns": {
+        "statId": {
+          "name": "statId",
+          "type": "varchar(128)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "date": {
+          "name": "date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "feature_type": {
+          "name": "feature_type",
+          "type": "feature_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "total_usage_count": {
+          "name": "total_usage_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "total_gems_consumed": {
+          "name": "total_gems_consumed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "unique_users": {
+          "name": "unique_users",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "success_rate": {
+          "name": "success_rate",
+          "type": "numeric(5, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0.00'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.gem_feature_costs": {
+      "name": "gem_feature_costs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(128)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "feature_type": {
+          "name": "feature_type",
+          "type": "feature_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "gem_cost": {
+          "name": "gem_cost",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "effective_from": {
+          "name": "effective_from",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "gem_feature_costs_feature_type_unique": {
+          "name": "gem_feature_costs_feature_type_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "feature_type"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.gem_payments": {
+      "name": "gem_payments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(128)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "product_id": {
+          "name": "product_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payment_method": {
+          "name": "payment_method",
+          "type": "payment_method",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payment_amount": {
+          "name": "payment_amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payment_status": {
+          "name": "payment_status",
+          "type": "payment_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'PENDING'"
+        },
+        "pg_transaction_id": {
+          "name": "pg_transaction_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "receipt_url": {
+          "name": "receipt_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "paid_at": {
+          "name": "paid_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "gem_payments_user_id_users_id_fk": {
+          "name": "gem_payments_user_id_users_id_fk",
+          "tableFrom": "gem_payments",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "gem_payments_product_id_gem_products_id_fk": {
+          "name": "gem_payments_product_id_gem_products_id_fk",
+          "tableFrom": "gem_payments",
+          "tableTo": "gem_products",
+          "columnsFrom": [
+            "product_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.gem_products": {
+      "name": "gem_products",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(128)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "product_name": {
+          "name": "product_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "gem_amount": {
+          "name": "gem_amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bonus_gems": {
+          "name": "bonus_gems",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "total_gems": {
+          "name": "total_gems",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "price": {
+          "name": "price",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "discount_rate": {
+          "name": "discount_rate",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.gem_transactions": {
+      "name": "gem_transactions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(128)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "transaction_type": {
+          "name": "transaction_type",
+          "type": "gem_transaction_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "gem_amount": {
+          "name": "gem_amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "balance_before": {
+          "name": "balance_before",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "balance_after": {
+          "name": "balance_after",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reference_type": {
+          "name": "reference_type",
+          "type": "gem_reference_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "gem_transactions_user_id_users_id_fk": {
+          "name": "gem_transactions_user_id_users_id_fk",
+          "tableFrom": "gem_transactions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.hot_articles": {
+      "name": "hot_articles",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(128)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "article_id": {
+          "name": "article_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "curator_comment": {
+          "name": "curator_comment",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "hot_articles_article_id_articles_id_fk": {
+          "name": "hot_articles_article_id_articles_id_fk",
+          "tableFrom": "hot_articles",
+          "tableTo": "articles",
+          "columnsFrom": [
+            "article_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.images": {
+      "name": "images",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(128)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "s3_url": {
+          "name": "s3_url",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "s3_key": {
+          "name": "s3_key",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "original_filename": {
+          "name": "original_filename",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mime_type": {
+          "name": "mime_type",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "size_in_bytes": {
+          "name": "size_in_bytes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_verified": {
+          "name": "is_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.likes": {
+      "name": "likes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(128)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "article_id": {
+          "name": "article_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "up": {
+          "name": "up",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "likes_user_id_users_id_fk": {
+          "name": "likes_user_id_users_id_fk",
+          "tableFrom": "likes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "likes_article_id_articles_id_fk": {
+          "name": "likes_article_id_articles_id_fk",
+          "tableFrom": "likes",
+          "tableTo": "articles",
+          "columnsFrom": [
+            "article_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.matches": {
+      "name": "matches",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(128)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "my_id": {
+          "name": "my_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "matcher_id": {
+          "name": "matcher_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "score": {
+          "name": "score",
+          "type": "numeric(8, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "direct": {
+          "name": "direct",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "published_at": {
+          "name": "published_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expired_at": {
+          "name": "expired_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(30)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "matches_my_id_users_id_fk": {
+          "name": "matches_my_id_users_id_fk",
+          "tableFrom": "matches",
+          "tableTo": "users",
+          "columnsFrom": [
+            "my_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "matches_matcher_id_users_id_fk": {
+          "name": "matches_matcher_id_users_id_fk",
+          "tableFrom": "matches",
+          "tableTo": "users",
+          "columnsFrom": [
+            "matcher_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.matching_failure_logs": {
+      "name": "matching_failure_logs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(128)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "matching_failure_logs_user_id_users_id_fk": {
+          "name": "matching_failure_logs_user_id_users_id_fk",
+          "tableFrom": "matching_failure_logs",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.matching_requests": {
+      "name": "matching_requests",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(128)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "score": {
+          "name": "score",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pay_histories": {
+      "name": "pay_histories",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(128)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "amount": {
+          "name": "amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "method": {
+          "name": "method",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "order_id": {
+          "name": "order_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "order_name": {
+          "name": "order_name",
+          "type": "varchar(30)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tx_id": {
+          "name": "tx_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payment_key": {
+          "name": "payment_key",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "receipt_url": {
+          "name": "receipt_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "paid_at": {
+          "name": "paid_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "pay_histories_user_id_users_id_fk": {
+          "name": "pay_histories_user_id_users_id_fk",
+          "tableFrom": "pay_histories",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.preference_options": {
+      "name": "preference_options",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(128)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "preference_type_id": {
+          "name": "preference_type_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "value": {
+          "name": "value",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "order": {
+          "name": "order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.preference_types": {
+      "name": "preference_types",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(128)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "code": {
+          "name": "code",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "multi_select": {
+          "name": "multi_select",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "maximum_choice_count": {
+          "name": "maximum_choice_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "preference_types_code_unique": {
+          "name": "preference_types_code_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "code"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.profile_images": {
+      "name": "profile_images",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(128)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "profile_id": {
+          "name": "profile_id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "image_id": {
+          "name": "image_id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "image_order": {
+          "name": "image_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_main": {
+          "name": "is_main",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "profile_images_profile_id_profiles_id_fk": {
+          "name": "profile_images_profile_id_profiles_id_fk",
+          "tableFrom": "profile_images",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "profile_images_image_id_images_id_fk": {
+          "name": "profile_images_image_id_images_id_fk",
+          "tableFrom": "profile_images",
+          "tableTo": "images",
+          "columnsFrom": [
+            "image_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.profiles": {
+      "name": "profiles",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(128)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "age": {
+          "name": "age",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "gender": {
+          "name": "gender",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(15)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mbti": {
+          "name": "mbti",
+          "type": "varchar(4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "instagram_id": {
+          "name": "instagram_id",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_matching_enable": {
+          "name": "is_matching_enable",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "introduction": {
+          "name": "introduction",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rank": {
+          "name": "rank",
+          "type": "varchar(7)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'UNKNOWN'"
+        },
+        "university_detail_id": {
+          "name": "university_detail_id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status_at": {
+          "name": "status_at",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "profiles_user_id_users_id_fk": {
+          "name": "profiles_user_id_users_id_fk",
+          "tableFrom": "profiles",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "profiles_user_id_unique": {
+          "name": "profiles_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.reports": {
+      "name": "reports",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(128)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "post_id": {
+          "name": "post_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reporter_id": {
+          "name": "reporter_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reported_id": {
+          "name": "reported_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(15)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "reports_post_id_articles_id_fk": {
+          "name": "reports_post_id_articles_id_fk",
+          "tableFrom": "reports",
+          "tableTo": "articles",
+          "columnsFrom": [
+            "post_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "reports_reporter_id_users_id_fk": {
+          "name": "reports_reporter_id_users_id_fk",
+          "tableFrom": "reports",
+          "tableTo": "users",
+          "columnsFrom": [
+            "reporter_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "reports_reported_id_users_id_fk": {
+          "name": "reports_reported_id_users_id_fk",
+          "tableFrom": "reports",
+          "tableTo": "users",
+          "columnsFrom": [
+            "reported_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sms_authorization": {
+      "name": "sms_authorization",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(128)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "phone_number": {
+          "name": "phone_number",
+          "type": "varchar(15)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "unique_key": {
+          "name": "unique_key",
+          "type": "varchar(62)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "authorization_code": {
+          "name": "authorization_code",
+          "type": "varchar(12)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_authorized": {
+          "name": "is_authorized",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tickets": {
+      "name": "tickets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(128)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(30)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "used_at": {
+          "name": "used_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expired_at": {
+          "name": "expired_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "tickets_user_id_users_id_fk": {
+          "name": "tickets_user_id_users_id_fk",
+          "tableFrom": "tickets",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.university_details": {
+      "name": "university_details",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(128)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "university_name": {
+          "name": "university_name",
+          "type": "varchar(30)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "department": {
+          "name": "department",
+          "type": "varchar(30)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "authentication": {
+          "name": "authentication",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "grade": {
+          "name": "grade",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "student_number": {
+          "name": "student_number",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "university_details_user_id_users_id_fk": {
+          "name": "university_details_user_id_users_id_fk",
+          "tableFrom": "university_details",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_gems": {
+      "name": "user_gems",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(128)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "gem_balance": {
+          "name": "gem_balance",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "total_charged": {
+          "name": "total_charged",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "total_consumed": {
+          "name": "total_consumed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_transaction_at": {
+          "name": "last_transaction_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_gems_user_id_users_id_fk": {
+          "name": "user_gems_user_id_users_id_fk",
+          "tableFrom": "user_gems",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_preference_options": {
+      "name": "user_preference_options",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(128)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_preference_id": {
+          "name": "user_preference_id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "preference_option_id": {
+          "name": "preference_option_id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "preference_target": {
+          "name": "preference_target",
+          "type": "preference_target",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'PARTNER'"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_preferences": {
+      "name": "user_preferences",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(128)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "distance_max": {
+          "name": "distance_max",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_preferences_user_id_users_id_fk": {
+          "name": "user_preferences_user_id_users_id_fk",
+          "tableFrom": "user_preferences",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_preferences_user_id_unique": {
+          "name": "user_preferences_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_range_preferences": {
+      "name": "user_range_preferences",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(128)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_preference_id": {
+          "name": "user_preference_id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "preference_type_id": {
+          "name": "preference_type_id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "min_value": {
+          "name": "min_value",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "max_value": {
+          "name": "max_value",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(128)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(15)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "phone_number": {
+          "name": "phone_number",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "birthday": {
+          "name": "birthday",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "profile_id": {
+          "name": "profile_id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "oauth_provider": {
+          "name": "oauth_provider",
+          "type": "varchar(30)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "suspended_at": {
+          "name": "suspended_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'user'"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.withdrawal_reasons": {
+      "name": "withdrawal_reasons",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(128)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/0018_snapshot.json
+++ b/drizzle/meta/0018_snapshot.json
@@ -1,0 +1,2509 @@
+{
+  "id": "58c8586f-30fe-4bbc-b43e-1bf4c8a15eb6",
+  "prevId": "a04e4a49-3299-44b4-9a44-d00933e34d1b",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.additional_preferences": {
+      "name": "additional_preferences",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(128)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "good_mbti": {
+          "name": "good_mbti",
+          "type": "varchar(4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bad_mbti": {
+          "name": "bad_mbti",
+          "type": "varchar(4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "profile_id": {
+          "name": "profile_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "additional_preferences_profile_id_profiles_id_fk": {
+          "name": "additional_preferences_profile_id_profiles_id_fk",
+          "tableFrom": "additional_preferences",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "additional_preferences_profile_id_unique": {
+          "name": "additional_preferences_profile_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "profile_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.article_categories": {
+      "name": "article_categories",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(128)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "emoji_url": {
+          "name": "emoji_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "varchar(20)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "code": {
+          "name": "code",
+          "type": "varchar(15)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.articles": {
+      "name": "articles",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(128)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(30)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "category_id": {
+          "name": "category_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "anonymous": {
+          "name": "anonymous",
+          "type": "varchar(15)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "like_count": {
+          "name": "like_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "blinded_at": {
+          "name": "blinded_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "read_count": {
+          "name": "read_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "articles_author_id_users_id_fk": {
+          "name": "articles_author_id_users_id_fk",
+          "tableFrom": "articles",
+          "tableTo": "users",
+          "columnsFrom": [
+            "author_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "articles_category_id_article_categories_id_fk": {
+          "name": "articles_category_id_article_categories_id_fk",
+          "tableFrom": "articles",
+          "tableTo": "article_categories",
+          "columnsFrom": [
+            "category_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.comments": {
+      "name": "comments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(128)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "author_id": {
+          "name": "author_id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "article_id": {
+          "name": "article_id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "parent_id": {
+          "name": "parent_id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "content": {
+          "name": "content",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "nickname": {
+          "name": "nickname",
+          "type": "varchar(15)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "blinded_at": {
+          "name": "blinded_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "comments_author_id_users_id_fk": {
+          "name": "comments_author_id_users_id_fk",
+          "tableFrom": "comments",
+          "tableTo": "users",
+          "columnsFrom": [
+            "author_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "comments_article_id_articles_id_fk": {
+          "name": "comments_article_id_articles_id_fk",
+          "tableFrom": "comments",
+          "tableTo": "articles",
+          "columnsFrom": [
+            "article_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "comments_parent_id_comments_id_fk": {
+          "name": "comments_parent_id_comments_id_fk",
+          "tableFrom": "comments",
+          "tableTo": "comments",
+          "columnsFrom": [
+            "parent_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.gem_daily_stats": {
+      "name": "gem_daily_stats",
+      "schema": "",
+      "columns": {
+        "statId": {
+          "name": "statId",
+          "type": "varchar(128)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "date": {
+          "name": "date",
+          "type": "date",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "feature_type": {
+          "name": "feature_type",
+          "type": "feature_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "total_usage_count": {
+          "name": "total_usage_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "total_gems_consumed": {
+          "name": "total_gems_consumed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "unique_users": {
+          "name": "unique_users",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "success_rate": {
+          "name": "success_rate",
+          "type": "numeric(5, 2)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'0.00'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.gem_feature_costs": {
+      "name": "gem_feature_costs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(128)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "feature_type": {
+          "name": "feature_type",
+          "type": "feature_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "gem_cost": {
+          "name": "gem_cost",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "effective_from": {
+          "name": "effective_from",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "gem_feature_costs_feature_type_unique": {
+          "name": "gem_feature_costs_feature_type_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "feature_type"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.gem_payments": {
+      "name": "gem_payments",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(128)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "product_id": {
+          "name": "product_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payment_method": {
+          "name": "payment_method",
+          "type": "payment_method",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payment_amount": {
+          "name": "payment_amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "payment_status": {
+          "name": "payment_status",
+          "type": "payment_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'PENDING'"
+        },
+        "pg_transaction_id": {
+          "name": "pg_transaction_id",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "receipt_url": {
+          "name": "receipt_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "paid_at": {
+          "name": "paid_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "gem_payments_user_id_users_id_fk": {
+          "name": "gem_payments_user_id_users_id_fk",
+          "tableFrom": "gem_payments",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "gem_payments_product_id_gem_products_id_fk": {
+          "name": "gem_payments_product_id_gem_products_id_fk",
+          "tableFrom": "gem_payments",
+          "tableTo": "gem_products",
+          "columnsFrom": [
+            "product_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.gem_products": {
+      "name": "gem_products",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(128)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "product_name": {
+          "name": "product_name",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "gem_amount": {
+          "name": "gem_amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "bonus_gems": {
+          "name": "bonus_gems",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "total_gems": {
+          "name": "total_gems",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "price": {
+          "name": "price",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "discount_rate": {
+          "name": "discount_rate",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "sort_order": {
+          "name": "sort_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.gem_transactions": {
+      "name": "gem_transactions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(128)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "transaction_type": {
+          "name": "transaction_type",
+          "type": "gem_transaction_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "gem_amount": {
+          "name": "gem_amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "balance_before": {
+          "name": "balance_before",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "balance_after": {
+          "name": "balance_after",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reference_type": {
+          "name": "reference_type",
+          "type": "gem_reference_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "gem_transactions_user_id_users_id_fk": {
+          "name": "gem_transactions_user_id_users_id_fk",
+          "tableFrom": "gem_transactions",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.hot_articles": {
+      "name": "hot_articles",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(128)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "article_id": {
+          "name": "article_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "curator_comment": {
+          "name": "curator_comment",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "hot_articles_article_id_articles_id_fk": {
+          "name": "hot_articles_article_id_articles_id_fk",
+          "tableFrom": "hot_articles",
+          "tableTo": "articles",
+          "columnsFrom": [
+            "article_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.images": {
+      "name": "images",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(128)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "s3_url": {
+          "name": "s3_url",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "s3_key": {
+          "name": "s3_key",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "original_filename": {
+          "name": "original_filename",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mime_type": {
+          "name": "mime_type",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "size_in_bytes": {
+          "name": "size_in_bytes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_verified": {
+          "name": "is_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.likes": {
+      "name": "likes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(128)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "article_id": {
+          "name": "article_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "up": {
+          "name": "up",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "likes_user_id_users_id_fk": {
+          "name": "likes_user_id_users_id_fk",
+          "tableFrom": "likes",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "likes_article_id_articles_id_fk": {
+          "name": "likes_article_id_articles_id_fk",
+          "tableFrom": "likes",
+          "tableTo": "articles",
+          "columnsFrom": [
+            "article_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.matches": {
+      "name": "matches",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(128)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "my_id": {
+          "name": "my_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "matcher_id": {
+          "name": "matcher_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "score": {
+          "name": "score",
+          "type": "numeric(8, 2)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "direct": {
+          "name": "direct",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "published_at": {
+          "name": "published_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expired_at": {
+          "name": "expired_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(30)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "matches_my_id_users_id_fk": {
+          "name": "matches_my_id_users_id_fk",
+          "tableFrom": "matches",
+          "tableTo": "users",
+          "columnsFrom": [
+            "my_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "matches_matcher_id_users_id_fk": {
+          "name": "matches_matcher_id_users_id_fk",
+          "tableFrom": "matches",
+          "tableTo": "users",
+          "columnsFrom": [
+            "matcher_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.matching_failure_logs": {
+      "name": "matching_failure_logs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(128)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "matching_failure_logs_user_id_users_id_fk": {
+          "name": "matching_failure_logs_user_id_users_id_fk",
+          "tableFrom": "matching_failure_logs",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.matching_requests": {
+      "name": "matching_requests",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(128)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "score": {
+          "name": "score",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pay_histories": {
+      "name": "pay_histories",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(128)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "amount": {
+          "name": "amount",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "method": {
+          "name": "method",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "order_id": {
+          "name": "order_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "order_name": {
+          "name": "order_name",
+          "type": "varchar(30)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tx_id": {
+          "name": "tx_id",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "payment_key": {
+          "name": "payment_key",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "receipt_url": {
+          "name": "receipt_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "paid_at": {
+          "name": "paid_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "pay_histories_user_id_users_id_fk": {
+          "name": "pay_histories_user_id_users_id_fk",
+          "tableFrom": "pay_histories",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.preference_options": {
+      "name": "preference_options",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(128)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "preference_type_id": {
+          "name": "preference_type_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "value": {
+          "name": "value",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "order": {
+          "name": "order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "deprecated": {
+          "name": "deprecated",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.preference_types": {
+      "name": "preference_types",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(128)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "code": {
+          "name": "code",
+          "type": "varchar(50)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "multi_select": {
+          "name": "multi_select",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "maximum_choice_count": {
+          "name": "maximum_choice_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "preference_types_code_unique": {
+          "name": "preference_types_code_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "code"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.profile_images": {
+      "name": "profile_images",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(128)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "profile_id": {
+          "name": "profile_id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "image_id": {
+          "name": "image_id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "image_order": {
+          "name": "image_order",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_main": {
+          "name": "is_main",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "profile_images_profile_id_profiles_id_fk": {
+          "name": "profile_images_profile_id_profiles_id_fk",
+          "tableFrom": "profile_images",
+          "tableTo": "profiles",
+          "columnsFrom": [
+            "profile_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "profile_images_image_id_images_id_fk": {
+          "name": "profile_images_image_id_images_id_fk",
+          "tableFrom": "profile_images",
+          "tableTo": "images",
+          "columnsFrom": [
+            "image_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.profiles": {
+      "name": "profiles",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(128)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "age": {
+          "name": "age",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "gender": {
+          "name": "gender",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(15)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "mbti": {
+          "name": "mbti",
+          "type": "varchar(4)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "instagram_id": {
+          "name": "instagram_id",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_matching_enable": {
+          "name": "is_matching_enable",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "introduction": {
+          "name": "introduction",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rank": {
+          "name": "rank",
+          "type": "varchar(7)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'UNKNOWN'"
+        },
+        "university_detail_id": {
+          "name": "university_detail_id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status_at": {
+          "name": "status_at",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "profiles_user_id_users_id_fk": {
+          "name": "profiles_user_id_users_id_fk",
+          "tableFrom": "profiles",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "profiles_user_id_unique": {
+          "name": "profiles_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.reports": {
+      "name": "reports",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(128)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "post_id": {
+          "name": "post_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reporter_id": {
+          "name": "reporter_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reported_id": {
+          "name": "reported_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "varchar(255)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(15)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "reports_post_id_articles_id_fk": {
+          "name": "reports_post_id_articles_id_fk",
+          "tableFrom": "reports",
+          "tableTo": "articles",
+          "columnsFrom": [
+            "post_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "reports_reporter_id_users_id_fk": {
+          "name": "reports_reporter_id_users_id_fk",
+          "tableFrom": "reports",
+          "tableTo": "users",
+          "columnsFrom": [
+            "reporter_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "reports_reported_id_users_id_fk": {
+          "name": "reports_reported_id_users_id_fk",
+          "tableFrom": "reports",
+          "tableTo": "users",
+          "columnsFrom": [
+            "reported_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sms_authorization": {
+      "name": "sms_authorization",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(128)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "phone_number": {
+          "name": "phone_number",
+          "type": "varchar(15)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "unique_key": {
+          "name": "unique_key",
+          "type": "varchar(62)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "authorization_code": {
+          "name": "authorization_code",
+          "type": "varchar(12)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_authorized": {
+          "name": "is_authorized",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.tickets": {
+      "name": "tickets",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(128)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(30)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "used_at": {
+          "name": "used_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expired_at": {
+          "name": "expired_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "tickets_user_id_users_id_fk": {
+          "name": "tickets_user_id_users_id_fk",
+          "tableFrom": "tickets",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.university_details": {
+      "name": "university_details",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(128)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "university_name": {
+          "name": "university_name",
+          "type": "varchar(30)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "department": {
+          "name": "department",
+          "type": "varchar(30)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "authentication": {
+          "name": "authentication",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "grade": {
+          "name": "grade",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "student_number": {
+          "name": "student_number",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "university_details_user_id_users_id_fk": {
+          "name": "university_details_user_id_users_id_fk",
+          "tableFrom": "university_details",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_gems": {
+      "name": "user_gems",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(128)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "gem_balance": {
+          "name": "gem_balance",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "total_charged": {
+          "name": "total_charged",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "total_consumed": {
+          "name": "total_consumed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_transaction_at": {
+          "name": "last_transaction_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_gems_user_id_users_id_fk": {
+          "name": "user_gems_user_id_users_id_fk",
+          "tableFrom": "user_gems",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_preference_options": {
+      "name": "user_preference_options",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(128)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_preference_id": {
+          "name": "user_preference_id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "preference_option_id": {
+          "name": "preference_option_id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "preference_target": {
+          "name": "preference_target",
+          "type": "preference_target",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'PARTNER'"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_preferences": {
+      "name": "user_preferences",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(128)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "distance_max": {
+          "name": "distance_max",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_preferences_user_id_users_id_fk": {
+          "name": "user_preferences_user_id_users_id_fk",
+          "tableFrom": "user_preferences",
+          "tableTo": "users",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_preferences_user_id_unique": {
+          "name": "user_preferences_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_range_preferences": {
+      "name": "user_range_preferences",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(128)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_preference_id": {
+          "name": "user_preference_id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "preference_type_id": {
+          "name": "preference_type_id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "min_value": {
+          "name": "min_value",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "max_value": {
+          "name": "max_value",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.users": {
+      "name": "users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(128)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "varchar(15)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "varchar(100)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "phone_number": {
+          "name": "phone_number",
+          "type": "varchar(16)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "birthday": {
+          "name": "birthday",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "profile_id": {
+          "name": "profile_id",
+          "type": "varchar(36)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "oauth_provider": {
+          "name": "oauth_provider",
+          "type": "varchar(30)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "varchar(500)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "suspended_at": {
+          "name": "suspended_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "varchar(10)",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'user'"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.withdrawal_reasons": {
+      "name": "withdrawal_reasons",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "varchar(128)",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "varchar(128)",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reason": {
+          "name": "reason",
+          "type": "varchar",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -120,6 +120,20 @@
       "when": 1751905726693,
       "tag": "0016_fixed_jackpot",
       "breakpoints": false
+    },
+    {
+      "idx": 17,
+      "version": "7",
+      "when": 1751967872900,
+      "tag": "0017_brave_silk_fever",
+      "breakpoints": false
+    },
+    {
+      "idx": 18,
+      "version": "7",
+      "when": 1751967958817,
+      "tag": "0018_calm_may_parker",
+      "breakpoints": false
     }
   ]
 }

--- a/sql/initial_data.sql
+++ b/sql/initial_data.sql
@@ -86,7 +86,346 @@ VALUES
   (gen_random_uuid(), (SELECT id FROM interest), 'MOVIES', '영화', NOW(), NOW(), 'https://sometimes-resources.s3.ap-northeast-2.amazonaws.com/icons/movie.png'),
   (gen_random_uuid(), (SELECT id FROM interest), 'MUSIC', '음악', NOW(), NOW(), 'https://sometimes-resources.s3.ap-northeast-2.amazonaws.com/icons/music.png'),
   (gen_random_uuid(), (SELECT id FROM interest), 'READING', '독서', NOW(), NOW(), 'https://sometimes-resources.s3.ap-northeast-2.amazonaws.com/icons/reading.png'),
-  (gen_random_uuid(), (SELECT id FROM interest), 'GAMING', '게임', NOW(), NOW(), 'https://sometimes-resources.s3.ap-northeast-2.amazonaws.com/icons/gaming.png'),
+  (gen_random_uuid(), (SELECT id FROM interest), 'GAMING', '게임', NOW(), NOW(), 'https://sometimes-resource-- preference_types 데이터 삽입 (중복 시 무시)
+INSERT INTO preference_types (id, code, name, multi_select, maximum_choice_count, created_at, updated_at)
+SELECT gen_random_uuid(), ''PERSONALITY'', ''성격 유형'', true, 1, NOW(), NOW()
+WHERE NOT EXISTS (SELECT 1 FROM preference_types WHERE code = ''PERSONALITY'')
+UNION ALL
+SELECT gen_random_uuid(), ''DATING_STYLE'', ''연애 스타일'', true, 3, NOW(), NOW()
+WHERE NOT EXISTS (SELECT 1 FROM preference_types WHERE code = ''DATING_STYLE'')
+UNION ALL
+SELECT gen_random_uuid(), ''LIFESTYLE'', ''라이프스타일'', true, 3, NOW(), NOW()
+WHERE NOT EXISTS (SELECT 1 FROM preference_types WHERE code = ''LIFESTYLE'')
+UNION ALL
+SELECT gen_random_uuid(), ''DRINKING'', ''음주 선호도'', false, 1, NOW(), NOW()
+WHERE NOT EXISTS (SELECT 1 FROM preference_types WHERE code = ''DRINKING'')
+UNION ALL
+SELECT gen_random_uuid(), ''SMOKING'', ''흡연 선호도'', false, 1, NOW(), NOW()
+WHERE NOT EXISTS (SELECT 1 FROM preference_types WHERE code = ''SMOKING'')
+UNION ALL
+SELECT gen_random_uuid(), ''TATTOO'', ''문신 선호도'', false, 1, NOW(), NOW()
+WHERE NOT EXISTS (SELECT 1 FROM preference_types WHERE code = ''TATTOO'')
+UNION ALL
+SELECT gen_random_uuid(), ''INTEREST'', ''관심사'', true, 5, NOW(), NOW()
+WHERE NOT EXISTS (SELECT 1 FROM preference_types WHERE code = ''INTEREST'')
+UNION ALL
+SELECT gen_random_uuid(), ''MBTI'', ''MBTI 유형'', false, 1, NOW(), NOW()
+WHERE NOT EXISTS (SELECT 1 FROM preference_types WHERE code = ''MBTI'')
+UNION ALL
+SELECT gen_random_uuid(), ''AGE_PREFERENCE'', ''선호 나이대'', false, 1, NOW(), NOW()
+WHERE NOT EXISTS (SELECT 1 FROM preference_types WHERE code = ''AGE_PREFERENCE'')
+UNION ALL
+SELECT gen_random_uuid(), ''MILITARY_STATUS_MALE'', ''군필 여부'', false, 1, NOW(), NOW()
+WHERE NOT EXISTS (SELECT 1 FROM preference_types WHERE code = ''MILITARY_STATUS_MALE'')
+UNION ALL
+SELECT gen_random_uuid(), ''MILITARY_PREFERENCE_FEMALE'', ''군필 여부 선호도'', false, 1, NOW(), NOW()
+WHERE NOT EXISTS (SELECT 1 FROM preference_types WHERE code = ''MILITARY_PREFERENCE_FEMALE'')
+UNION ALL
+SELECT gen_random_uuid(), ''personality'', ''성격'', false, 1, NOW(), NOW()
+WHERE NOT EXISTS (SELECT 1 FROM preference_types WHERE code = ''personality'');
+
+-- preference_options 데이터 삽입 - 성격 유형 (PERSONALITY)
+INSERT INTO preference_options (id, preference_type_id, value, display_name, "order", deprecated, created_at, updated_at)
+SELECT gen_random_uuid(), (SELECT id FROM preference_types WHERE code = ''PERSONALITY''), ''OUTGOING'', ''활발한 성격'', 0, false, NOW(), NOW()
+WHERE NOT EXISTS (SELECT 1 FROM preference_options po JOIN preference_types pt ON po.preference_type_id = pt.id WHERE pt.code = ''PERSONALITY'' AND po.value = ''OUTGOING'')
+UNION ALL
+SELECT gen_random_uuid(), (SELECT id FROM preference_types WHERE code = ''PERSONALITY''), ''QUIET'', ''조용한 성격'', 1, false, NOW(), NOW()
+WHERE NOT EXISTS (SELECT 1 FROM preference_options po JOIN preference_types pt ON po.preference_type_id = pt.id WHERE pt.code = ''PERSONALITY'' AND po.value = ''QUIET'')
+UNION ALL
+SELECT gen_random_uuid(), (SELECT id FROM preference_types WHERE code = ''PERSONALITY''), ''CARING'', ''배려심 많은 사람'', 2, false, NOW(), NOW()
+WHERE NOT EXISTS (SELECT 1 FROM preference_options po JOIN preference_types pt ON po.preference_type_id = pt.id WHERE pt.code = ''PERSONALITY'' AND po.value = ''CARING'')
+UNION ALL
+SELECT gen_random_uuid(), (SELECT id FROM preference_types WHERE code = ''PERSONALITY''), ''LEADER'', ''리더십 있는 사람'', 3, false, NOW(), NOW()
+WHERE NOT EXISTS (SELECT 1 FROM preference_options po JOIN preference_types pt ON po.preference_type_id = pt.id WHERE pt.code = ''PERSONALITY'' AND po.value = ''LEADER'')
+UNION ALL
+SELECT gen_random_uuid(), (SELECT id FROM preference_types WHERE code = ''PERSONALITY''), ''HUMOROUS'', ''유머 감각 있는 사람'', 4, false, NOW(), NOW()
+WHERE NOT EXISTS (SELECT 1 FROM preference_options po JOIN preference_types pt ON po.preference_type_id = pt.id WHERE pt.code = ''PERSONALITY'' AND po.value = ''HUMOROUS'')
+UNION ALL
+SELECT gen_random_uuid(), (SELECT id FROM preference_types WHERE code = ''PERSONALITY''), ''EMOTIONAL'', ''감성적인 사람'', 5, false, NOW(), NOW()
+WHERE NOT EXISTS (SELECT 1 FROM preference_options po JOIN preference_types pt ON po.preference_type_id = pt.id WHERE pt.code = ''PERSONALITY'' AND po.value = ''EMOTIONAL'')
+UNION ALL
+SELECT gen_random_uuid(), (SELECT id FROM preference_types WHERE code = ''PERSONALITY''), ''ADVENTUROUS'', ''모험을 즐기는 사람'', 6, false, NOW(), NOW()
+WHERE NOT EXISTS (SELECT 1 FROM preference_options po JOIN preference_types pt ON po.preference_type_id = pt.id WHERE pt.code = ''PERSONALITY'' AND po.value = ''ADVENTUROUS'')
+UNION ALL
+SELECT gen_random_uuid(), (SELECT id FROM preference_types WHERE code = ''PERSONALITY''), ''PLANNER'', ''계획적인 스타일'', 7, false, NOW(), NOW()
+WHERE NOT EXISTS (SELECT 1 FROM preference_options po JOIN preference_types pt ON po.preference_type_id = pt.id WHERE pt.code = ''PERSONALITY'' AND po.value = ''PLANNER'')
+UNION ALL
+SELECT gen_random_uuid(), (SELECT id FROM preference_types WHERE code = ''PERSONALITY''), ''SPONTANEOUS'', ''즉흥적인 스타일'', 8, false, NOW(), NOW()
+WHERE NOT EXISTS (SELECT 1 FROM preference_options po JOIN preference_types pt ON po.preference_type_id = pt.id WHERE pt.code = ''PERSONALITY'' AND po.value = ''SPONTANEOUS'');
+
+-- preference_options 데이터 삽입 - 성격 (personality)
+INSERT INTO preference_options (id, preference_type_id, value, display_name, "order", deprecated, created_at, updated_at)
+SELECT gen_random_uuid(), (SELECT id FROM preference_types WHERE code = ''personality''), ''quiet'', ''조용한 성격'', 0, false, NOW(), NOW()
+WHERE NOT EXISTS (SELECT 1 FROM preference_options po JOIN preference_types pt ON po.preference_type_id = pt.id WHERE pt.code = ''personality'' AND po.value = ''quiet'')
+UNION ALL
+SELECT gen_random_uuid(), (SELECT id FROM preference_types WHERE code = ''personality''), ''active'', ''활발한 성격'', 1, false, NOW(), NOW()
+WHERE NOT EXISTS (SELECT 1 FROM preference_options po JOIN preference_types pt ON po.preference_type_id = pt.id WHERE pt.code = ''personality'' AND po.value = ''active'')
+UNION ALL
+SELECT gen_random_uuid(), (SELECT id FROM preference_types WHERE code = ''personality''), ''spontaneous'', ''즉흥적인 스타일'', 2, false, NOW(), NOW()
+WHERE NOT EXISTS (SELECT 1 FROM preference_options po JOIN preference_types pt ON po.preference_type_id = pt.id WHERE pt.code = ''personality'' AND po.value = ''spontaneous'')
+UNION ALL
+SELECT gen_random_uuid(), (SELECT id FROM preference_types WHERE code = ''personality''), ''planned'', ''계획적인 스타일'', 3, false, NOW(), NOW()
+WHERE NOT EXISTS (SELECT 1 FROM preference_options po JOIN preference_types pt ON po.preference_type_id = pt.id WHERE pt.code = ''personality'' AND po.value = ''planned'')
+UNION ALL
+SELECT gen_random_uuid(), (SELECT id FROM preference_types WHERE code = ''personality''), ''adventurous'', ''모험을 즐기는 사람'', 4, false, NOW(), NOW()
+WHERE NOT EXISTS (SELECT 1 FROM preference_options po JOIN preference_types pt ON po.preference_type_id = pt.id WHERE pt.code = ''personality'' AND po.value = ''adventurous'')
+UNION ALL
+SELECT gen_random_uuid(), (SELECT id FROM preference_types WHERE code = ''personality''), ''emotional'', ''감성적인 사람'', 5, false, NOW(), NOW()
+WHERE NOT EXISTS (SELECT 1 FROM preference_options po JOIN preference_types pt ON po.preference_type_id = pt.id WHERE pt.code = ''personality'' AND po.value = ''emotional'')
+UNION ALL
+SELECT gen_random_uuid(), (SELECT id FROM preference_types WHERE code = ''personality''), ''caring'', ''배려심 많은 사람'', 6, false, NOW(), NOW()
+WHERE NOT EXISTS (SELECT 1 FROM preference_options po JOIN preference_types pt ON po.preference_type_id = pt.id WHERE pt.code = ''personality'' AND po.value = ''caring'')
+UNION ALL
+SELECT gen_random_uuid(), (SELECT id FROM preference_types WHERE code = ''personality''), ''humorous'', ''유머감각 있는 사람'', 7, false, NOW(), NOW()
+WHERE NOT EXISTS (SELECT 1 FROM preference_options po JOIN preference_types pt ON po.preference_type_id = pt.id WHERE pt.code = ''personality'' AND po.value = ''humorous'')
+UNION ALL
+SELECT gen_random_uuid(), (SELECT id FROM preference_types WHERE code = ''personality''), ''leadership'', ''리더십 있는 사람'', 8, false, NOW(), NOW()
+WHERE NOT EXISTS (SELECT 1 FROM preference_options po JOIN preference_types pt ON po.preference_type_id = pt.id WHERE pt.code = ''personality'' AND po.value = ''leadership'');
+
+-- preference_options 데이터 삽입 - 음주 선호도 (DRINKING)
+INSERT INTO preference_options (id, preference_type_id, value, display_name, "order", deprecated, created_at, updated_at)
+SELECT gen_random_uuid(), (SELECT id FROM preference_types WHERE code = ''DRINKING''), ''PREFER_NONE'', ''안마시면 좋겠음'', 0, false, NOW(), NOW()
+WHERE NOT EXISTS (SELECT 1 FROM preference_options po JOIN preference_types pt ON po.preference_type_id = pt.id WHERE pt.code = ''DRINKING'' AND po.value = ''PREFER_NONE'')
+UNION ALL
+SELECT gen_random_uuid(), (SELECT id FROM preference_types WHERE code = ''DRINKING''), ''PREFER_OCCASIONALLY'', ''가끔마시면 좋겠음'', 1, false, NOW(), NOW()
+WHERE NOT EXISTS (SELECT 1 FROM preference_options po JOIN preference_types pt ON po.preference_type_id = pt.id WHERE pt.code = ''DRINKING'' AND po.value = ''PREFER_OCCASIONALLY'')
+UNION ALL
+SELECT gen_random_uuid(), (SELECT id FROM preference_types WHERE code = ''DRINKING''), ''PREFER_MODERATE'', ''적당히 마시면 좋겠음'', 2, false, NOW(), NOW()
+WHERE NOT EXISTS (SELECT 1 FROM preference_options po JOIN preference_types pt ON po.preference_type_id = pt.id WHERE pt.code = ''DRINKING'' AND po.value = ''PREFER_MODERATE'')
+UNION ALL
+SELECT gen_random_uuid(), (SELECT id FROM preference_types WHERE code = ''DRINKING''), ''OKAY'', ''마셔도 괜찮음'', 3, false, NOW(), NOW()
+WHERE NOT EXISTS (SELECT 1 FROM preference_options po JOIN preference_types pt ON po.preference_type_id = pt.id WHERE pt.code = ''DRINKING'' AND po.value = ''OKAY'')
+UNION ALL
+SELECT gen_random_uuid(), (SELECT id FROM preference_types WHERE code = ''DRINKING''), ''FREQUENT_OKAY'', ''자주 마셔도 괜찮음'', 4, false, NOW(), NOW()
+WHERE NOT EXISTS (SELECT 1 FROM preference_options po JOIN preference_types pt ON po.preference_type_id = pt.id WHERE pt.code = ''DRINKING'' AND po.value = ''FREQUENT_OKAY'')
+UNION ALL
+SELECT gen_random_uuid(), (SELECT id FROM preference_types WHERE code = ''DRINKING''), ''NEVER'', ''전혀 안마시지 않음'', 0, false, NOW(), NOW()
+WHERE NOT EXISTS (SELECT 1 FROM preference_options po JOIN preference_types pt ON po.preference_type_id = pt.id WHERE pt.code = ''DRINKING'' AND po.value = ''NEVER'')
+UNION ALL
+SELECT gen_random_uuid(), (SELECT id FROM preference_types WHERE code = ''DRINKING''), ''RARELY'', ''거의 못마심'', 1, false, NOW(), NOW()
+WHERE NOT EXISTS (SELECT 1 FROM preference_options po JOIN preference_types pt ON po.preference_type_id = pt.id WHERE pt.code = ''DRINKING'' AND po.value = ''RARELY'')
+UNION ALL
+SELECT gen_random_uuid(), (SELECT id FROM preference_types WHERE code = ''DRINKING''), ''MODERATE'', ''적당히 마심'', 2, false, NOW(), NOW()
+WHERE NOT EXISTS (SELECT 1 FROM preference_options po JOIN preference_types pt ON po.preference_type_id = pt.id WHERE pt.code = ''DRINKING'' AND po.value = ''MODERATE'')
+UNION ALL
+SELECT gen_random_uuid(), (SELECT id FROM preference_types WHERE code = ''DRINKING''), ''FREQUENT'', ''자주 마심'', 3, false, NOW(), NOW()
+WHERE NOT EXISTS (SELECT 1 FROM preference_options po JOIN preference_types pt ON po.preference_type_id = pt.id WHERE pt.code = ''DRINKING'' AND po.value = ''FREQUENT'')
+UNION ALL
+SELECT gen_random_uuid(), (SELECT id FROM preference_types WHERE code = ''DRINKING''), ''VERY_FREQUENT'', ''매우 즐겨 마심'', 4, false, NOW(), NOW()
+WHERE NOT EXISTS (SELECT 1 FROM preference_options po JOIN preference_types pt ON po.preference_type_id = pt.id WHERE pt.code = ''DRINKING'' AND po.value = ''VERY_FREQUENT'');
+
+-- preference_options 데이터 삽입 - 흡연 선호도 (SMOKING)
+INSERT INTO preference_options (id, preference_type_id, value, display_name, "order", deprecated, created_at, updated_at)
+SELECT gen_random_uuid(), (SELECT id FROM preference_types WHERE code = ''SMOKING''), ''NON_SMOKER'', ''비흡연자'', 0, false, NOW(), NOW()
+WHERE NOT EXISTS (SELECT 1 FROM preference_options po JOIN preference_types pt ON po.preference_type_id = pt.id WHERE pt.code = ''SMOKING'' AND po.value = ''NON_SMOKER'')
+UNION ALL
+SELECT gen_random_uuid(), (SELECT id FROM preference_types WHERE code = ''SMOKING''), ''E_CIGARETTE'', ''전자담배'', 1, false, NOW(), NOW()
+WHERE NOT EXISTS (SELECT 1 FROM preference_options po JOIN preference_types pt ON po.preference_type_id = pt.id WHERE pt.code = ''SMOKING'' AND po.value = ''E_CIGARETTE'')
+UNION ALL
+SELECT gen_random_uuid(), (SELECT id FROM preference_types WHERE code = ''SMOKING''), ''NO_PREFERENCE'', ''상관없음'', 1, false, NOW(), NOW()
+WHERE NOT EXISTS (SELECT 1 FROM preference_options po JOIN preference_types pt ON po.preference_type_id = pt.id WHERE pt.code = ''SMOKING'' AND po.value = ''NO_PREFERENCE'')
+UNION ALL
+SELECT gen_random_uuid(), (SELECT id FROM preference_types WHERE code = ''SMOKING''), ''SMOKER'', ''흡연자'', 2, false, NOW(), NOW()
+WHERE NOT EXISTS (SELECT 1 FROM preference_options po JOIN preference_types pt ON po.preference_type_id = pt.id WHERE pt.code = ''SMOKING'' AND po.value = ''SMOKER'');
+
+-- preference_options 데이터 삽입 - 문신 선호도 (TATTOO)
+INSERT INTO preference_options (id, preference_type_id, value, display_name, "order", deprecated, created_at, updated_at)
+SELECT gen_random_uuid(), (SELECT id FROM preference_types WHERE code = ''TATTOO''), ''NONE_STRICT'', ''문신 X'', 0, false, NOW(), NOW()
+WHERE NOT EXISTS (SELECT 1 FROM preference_options po JOIN preference_types pt ON po.preference_type_id = pt.id WHERE pt.code = ''TATTOO'' AND po.value = ''NONE_STRICT'')
+UNION ALL
+SELECT gen_random_uuid(), (SELECT id FROM preference_types WHERE code = ''TATTOO''), ''SMALL'', ''작은 문신'', 1, false, NOW(), NOW()
+WHERE NOT EXISTS (SELECT 1 FROM preference_options po JOIN preference_types pt ON po.preference_type_id = pt.id WHERE pt.code = ''TATTOO'' AND po.value = ''SMALL'')
+UNION ALL
+SELECT gen_random_uuid(), (SELECT id FROM preference_types WHERE code = ''TATTOO''), ''NONE'', ''문신 없음'', 1, false, NOW(), NOW()
+WHERE NOT EXISTS (SELECT 1 FROM preference_options po JOIN preference_types pt ON po.preference_type_id = pt.id WHERE pt.code = ''TATTOO'' AND po.value = ''NONE'')
+UNION ALL
+SELECT gen_random_uuid(), (SELECT id FROM preference_types WHERE code = ''TATTOO''), ''OKAY'', ''문신 O'', 2, false, NOW(), NOW()
+WHERE NOT EXISTS (SELECT 1 FROM preference_options po JOIN preference_types pt ON po.preference_type_id = pt.id WHERE pt.code = ''TATTOO'' AND po.value = ''OKAY'');
+
+-- preference_options 데이터 삽입 - 군필 여부 (MILITARY_STATUS_MALE)
+INSERT INTO preference_options (id, preference_type_id, value, display_name, "order", deprecated, created_at, updated_at)
+SELECT gen_random_uuid(), (SELECT id FROM preference_types WHERE code = ''MILITARY_STATUS_MALE''), ''NOT_SERVED'', ''미필'', 0, false, NOW(), NOW()
+WHERE NOT EXISTS (SELECT 1 FROM preference_options po JOIN preference_types pt ON po.preference_type_id = pt.id WHERE pt.code = ''MILITARY_STATUS_MALE'' AND po.value = ''NOT_SERVED'')
+UNION ALL
+SELECT gen_random_uuid(), (SELECT id FROM preference_types WHERE code = ''MILITARY_STATUS_MALE''), ''EXEMPTED'', ''면제'', 1, false, NOW(), NOW()
+WHERE NOT EXISTS (SELECT 1 FROM preference_options po JOIN preference_types pt ON po.preference_type_id = pt.id WHERE pt.code = ''MILITARY_STATUS_MALE'' AND po.value = ''EXEMPTED'')
+UNION ALL
+SELECT gen_random_uuid(), (SELECT id FROM preference_types WHERE code = ''MILITARY_STATUS_MALE''), ''SERVED'', ''군필'', 2, false, NOW(), NOW()
+WHERE NOT EXISTS (SELECT 1 FROM preference_options po JOIN preference_types pt ON po.preference_type_id = pt.id WHERE pt.code = ''MILITARY_STATUS_MALE'' AND po.value = ''SERVED'');
+
+-- preference_options 데이터 삽입 - 군필 여부 선호도 (MILITARY_PREFERENCE_FEMALE)
+INSERT INTO preference_options (id, preference_type_id, value, display_name, "order", deprecated, created_at, updated_at)
+SELECT gen_random_uuid(), (SELECT id FROM preference_types WHERE code = ''MILITARY_PREFERENCE_FEMALE''), ''NOT_SERVED'', ''미필'', 0, false, NOW(), NOW()
+WHERE NOT EXISTS (SELECT 1 FROM preference_options po JOIN preference_types pt ON po.preference_type_id = pt.id WHERE pt.code = ''MILITARY_PREFERENCE_FEMALE'' AND po.value = ''NOT_SERVED'')
+UNION ALL
+SELECT gen_random_uuid(), (SELECT id FROM preference_types WHERE code = ''MILITARY_PREFERENCE_FEMALE''), ''NO_PREFERENCE'', ''상관없음'', 1, false, NOW(), NOW()
+WHERE NOT EXISTS (SELECT 1 FROM preference_options po JOIN preference_types pt ON po.preference_type_id = pt.id WHERE pt.code = ''MILITARY_PREFERENCE_FEMALE'' AND po.value = ''NO_PREFERENCE'')
+UNION ALL
+SELECT gen_random_uuid(), (SELECT id FROM preference_types WHERE code = ''MILITARY_PREFERENCE_FEMALE''), ''SERVED'', ''군필'', 2, false, NOW(), NOW()
+WHERE NOT EXISTS (SELECT 1 FROM preference_options po JOIN preference_types pt ON po.preference_type_id = pt.id WHERE pt.code = ''MILITARY_PREFERENCE_FEMALE'' AND po.value = ''SERVED'');
+
+-- preference_options 데이터 삽입 - 연애 스타일 (DATING_STYLE)
+INSERT INTO preference_options (id, preference_type_id, value, display_name, "order", deprecated, created_at, updated_at)
+SELECT gen_random_uuid(), (SELECT id FROM preference_types WHERE code = ''DATING_STYLE''), ''PROACTIVE'', ''적극적인 스타일'', 0, false, NOW(), NOW()
+WHERE NOT EXISTS (SELECT 1 FROM preference_options po JOIN preference_types pt ON po.preference_type_id = pt.id WHERE pt.code = ''DATING_STYLE'' AND po.value = ''PROACTIVE'')
+UNION ALL
+SELECT gen_random_uuid(), (SELECT id FROM preference_types WHERE code = ''DATING_STYLE''), ''AFFECTIONATE'', ''다정다감한 스타일'', 1, false, NOW(), NOW()
+WHERE NOT EXISTS (SELECT 1 FROM preference_options po JOIN preference_types pt ON po.preference_type_id = pt.id WHERE pt.code = ''DATING_STYLE'' AND po.value = ''AFFECTIONATE'')
+UNION ALL
+SELECT gen_random_uuid(), (SELECT id FROM preference_types WHERE code = ''DATING_STYLE''), ''FRIENDLY'', ''친구처럼 지내는 스타일'', 2, false, NOW(), NOW()
+WHERE NOT EXISTS (SELECT 1 FROM preference_options po JOIN preference_types pt ON po.preference_type_id = pt.id WHERE pt.code = ''DATING_STYLE'' AND po.value = ''FRIENDLY'')
+UNION ALL
+SELECT gen_random_uuid(), (SELECT id FROM preference_types WHERE code = ''DATING_STYLE''), ''TSUNDERE'', ''츤데레 스타일'', 3, false, NOW(), NOW()
+WHERE NOT EXISTS (SELECT 1 FROM preference_options po JOIN preference_types pt ON po.preference_type_id = pt.id WHERE pt.code = ''DATING_STYLE'' AND po.value = ''TSUNDERE'')
+UNION ALL
+SELECT gen_random_uuid(), (SELECT id FROM preference_types WHERE code = ''DATING_STYLE''), ''ATTENTIVE'', ''상대방을 많이 챙기는 스타일'', 4, false, NOW(), NOW()
+WHERE NOT EXISTS (SELECT 1 FROM preference_options po JOIN preference_types pt ON po.preference_type_id = pt.id WHERE pt.code = ''DATING_STYLE'' AND po.value = ''ATTENTIVE'')
+UNION ALL
+SELECT gen_random_uuid(), (SELECT id FROM preference_types WHERE code = ''DATING_STYLE''), ''RESERVED_BUT_CARING'', ''표현을 잘 안 하지만 속은 다정한 스타일'', 5, false, NOW(), NOW()
+WHERE NOT EXISTS (SELECT 1 FROM preference_options po JOIN preference_types pt ON po.preference_type_id = pt.id WHERE pt.code = ''DATING_STYLE'' AND po.value = ''RESERVED_BUT_CARING'')
+UNION ALL
+SELECT gen_random_uuid(), (SELECT id FROM preference_types WHERE code = ''DATING_STYLE''), ''FREE_SPIRITED'', ''자유로운 연애를 선호하는 스타일'', 6, false, NOW(), NOW()
+WHERE NOT EXISTS (SELECT 1 FROM preference_options po JOIN preference_types pt ON po.preference_type_id = pt.id WHERE pt.code = ''DATING_STYLE'' AND po.value = ''FREE_SPIRITED'')
+UNION ALL
+SELECT gen_random_uuid(), (SELECT id FROM preference_types WHERE code = ''DATING_STYLE''), ''FREQUENT_CONTACT'', ''자주 연락하는 걸 선호하는 스타일'', 7, false, NOW(), NOW()
+WHERE NOT EXISTS (SELECT 1 FROM preference_options po JOIN preference_types pt ON po.preference_type_id = pt.id WHERE pt.code = ''DATING_STYLE'' AND po.value = ''FREQUENT_CONTACT'');
+
+-- preference_options 데이터 삽입 - 라이프스타일 (LIFESTYLE)
+INSERT INTO preference_options (id, preference_type_id, value, display_name, "order", deprecated, created_at, updated_at)
+SELECT gen_random_uuid(), (SELECT id FROM preference_types WHERE code = ''LIFESTYLE''), ''MORNING_PERSON'', ''아침형 인간'', 0, false, NOW(), NOW()
+WHERE NOT EXISTS (SELECT 1 FROM preference_options po JOIN preference_types pt ON po.preference_type_id = pt.id WHERE pt.code = ''LIFESTYLE'' AND po.value = ''MORNING_PERSON'')
+UNION ALL
+SELECT gen_random_uuid(), (SELECT id FROM preference_types WHERE code = ''LIFESTYLE''), ''NIGHT_PERSON'', ''밤형 인간'', 1, false, NOW(), NOW()
+WHERE NOT EXISTS (SELECT 1 FROM preference_options po JOIN preference_types pt ON po.preference_type_id = pt.id WHERE pt.code = ''LIFESTYLE'' AND po.value = ''NIGHT_PERSON'')
+UNION ALL
+SELECT gen_random_uuid(), (SELECT id FROM preference_types WHERE code = ''LIFESTYLE''), ''HOMEBODY'', ''집순이 / 집돌이'', 2, false, NOW(), NOW()
+WHERE NOT EXISTS (SELECT 1 FROM preference_options po JOIN preference_types pt ON po.preference_type_id = pt.id WHERE pt.code = ''LIFESTYLE'' AND po.value = ''HOMEBODY'')
+UNION ALL
+SELECT gen_random_uuid(), (SELECT id FROM preference_types WHERE code = ''LIFESTYLE''), ''TRAVELER'', ''여행을 자주 다니는 편'', 3, false, NOW(), NOW()
+WHERE NOT EXISTS (SELECT 1 FROM preference_options po JOIN preference_types pt ON po.preference_type_id = pt.id WHERE pt.code = ''LIFESTYLE'' AND po.value = ''TRAVELER'')
+UNION ALL
+SELECT gen_random_uuid(), (SELECT id FROM preference_types WHERE code = ''LIFESTYLE''), ''ACTIVE'', ''운동을 즐기는 편'', 4, false, NOW(), NOW()
+WHERE NOT EXISTS (SELECT 1 FROM preference_options po JOIN preference_types pt ON po.preference_type_id = pt.id WHERE pt.code = ''LIFESTYLE'' AND po.value = ''ACTIVE'')
+UNION ALL
+SELECT gen_random_uuid(), (SELECT id FROM preference_types WHERE code = ''LIFESTYLE''), ''GAMER'', ''게임을 자주 하는 편'', 5, false, NOW(), NOW()
+WHERE NOT EXISTS (SELECT 1 FROM preference_options po JOIN preference_types pt ON po.preference_type_id = pt.id WHERE pt.code = ''LIFESTYLE'' AND po.value = ''GAMER'')
+UNION ALL
+SELECT gen_random_uuid(), (SELECT id FROM preference_types WHERE code = ''LIFESTYLE''), ''CAFE_LOVER'', ''카페에서 노는 걸 좋아함'', 6, false, NOW(), NOW()
+WHERE NOT EXISTS (SELECT 1 FROM preference_options po JOIN preference_types pt ON po.preference_type_id = pt.id WHERE pt.code = ''LIFESTYLE'' AND po.value = ''CAFE_LOVER'')
+UNION ALL
+SELECT gen_random_uuid(), (SELECT id FROM preference_types WHERE code = ''LIFESTYLE''), ''ACTIVITY_LOVER'', ''액티비티 활동을 좋아함'', 7, false, NOW(), NOW()
+WHERE NOT EXISTS (SELECT 1 FROM preference_options po JOIN preference_types pt ON po.preference_type_id = pt.id WHERE pt.code = ''LIFESTYLE'' AND po.value = ''ACTIVITY_LOVER'');
+
+-- preference_options 데이터 삽입 - 관심사 (INTEREST)
+INSERT INTO preference_options (id, preference_type_id, value, display_name, image_url, "order", deprecated, created_at, updated_at)
+SELECT gen_random_uuid(), (SELECT id FROM preference_types WHERE code = ''INTEREST''), ''MOVIES'', ''영화'', ''https://sometimes-resources.s3.ap-northeast-2.amazonaws.com/icons/movie.png'', 0, false, NOW(), NOW()
+WHERE NOT EXISTS (SELECT 1 FROM preference_options po JOIN preference_types pt ON po.preference_type_id = pt.id WHERE pt.code = ''INTEREST'' AND po.value = ''MOVIES'')
+UNION ALL
+SELECT gen_random_uuid(), (SELECT id FROM preference_types WHERE code = ''INTEREST''), ''MUSIC'', ''음악'', ''https://sometimes-resources.s3.ap-northeast-2.amazonaws.com/icons/music.png'', 1, false, NOW(), NOW()
+WHERE NOT EXISTS (SELECT 1 FROM preference_options po JOIN preference_types pt ON po.preference_type_id = pt.id WHERE pt.code = ''INTEREST'' AND po.value = ''MUSIC'')
+UNION ALL
+SELECT gen_random_uuid(), (SELECT id FROM preference_types WHERE code = ''INTEREST''), ''READING'', ''독서'', ''https://sometimes-resources.s3.ap-northeast-2.amazonaws.com/icons/reading.png'', 2, false, NOW(), NOW()
+WHERE NOT EXISTS (SELECT 1 FROM preference_options po JOIN preference_types pt ON po.preference_type_id = pt.id WHERE pt.code = ''INTEREST'' AND po.value = ''READING'')
+UNION ALL
+SELECT gen_random_uuid(), (SELECT id FROM preference_types WHERE code = ''INTEREST''), ''GAMING'', ''게임'', ''https://sometimes-resources.s3.ap-northeast-2.amazonaws.com/icons/gaming.png'', 3, false, NOW(), NOW()
+WHERE NOT EXISTS (SELECT 1 FROM preference_options po JOIN preference_types pt ON po.preference_type_id = pt.id WHERE pt.code = ''INTEREST'' AND po.value = ''GAMING'')
+UNION ALL
+SELECT gen_random_uuid(), (SELECT id FROM preference_types WHERE code = ''INTEREST''), ''SPORTS'', ''운동'', ''https://sometimes-resources.s3.ap-northeast-2.amazonaws.com/icons/exercise.png'', 4, false, NOW(), NOW()
+WHERE NOT EXISTS (SELECT 1 FROM preference_options po JOIN preference_types pt ON po.preference_type_id = pt.id WHERE pt.code = ''INTEREST'' AND po.value = ''SPORTS'')
+UNION ALL
+SELECT gen_random_uuid(), (SELECT id FROM preference_types WHERE code = ''INTEREST''), ''COOKING'', ''요리'', ''https://sometimes-resources.s3.ap-northeast-2.amazonaws.com/icons/cooking.png'', 5, false, NOW(), NOW()
+WHERE NOT EXISTS (SELECT 1 FROM preference_options po JOIN preference_types pt ON po.preference_type_id = pt.id WHERE pt.code = ''INTEREST'' AND po.value = ''COOKING'')
+UNION ALL
+SELECT gen_random_uuid(), (SELECT id FROM preference_types WHERE code = ''INTEREST''), ''TRAVEL'', ''여행'', ''https://sometimes-resources.s3.ap-northeast-2.amazonaws.com/icons/travel.png'', 6, false, NOW(), NOW()
+WHERE NOT EXISTS (SELECT 1 FROM preference_options po JOIN preference_types pt ON po.preference_type_id = pt.id WHERE pt.code = ''INTEREST'' AND po.value = ''TRAVEL'')
+UNION ALL
+SELECT gen_random_uuid(), (SELECT id FROM preference_types WHERE code = ''INTEREST''), ''PHOTOGRAPHY'', ''사진'', ''https://sometimes-resources.s3.ap-northeast-2.amazonaws.com/icons/capture.png'', 7, false, NOW(), NOW()
+WHERE NOT EXISTS (SELECT 1 FROM preference_options po JOIN preference_types pt ON po.preference_type_id = pt.id WHERE pt.code = ''INTEREST'' AND po.value = ''PHOTOGRAPHY'')
+UNION ALL
+SELECT gen_random_uuid(), (SELECT id FROM preference_types WHERE code = ''INTEREST''), ''FASHION'', ''패션'', ''https://sometimes-resources.s3.ap-northeast-2.amazonaws.com/icons/fashion.png'', 8, false, NOW(), NOW()
+WHERE NOT EXISTS (SELECT 1 FROM preference_options po JOIN preference_types pt ON po.preference_type_id = pt.id WHERE pt.code = ''INTEREST'' AND po.value = ''FASHION'')
+UNION ALL
+SELECT gen_random_uuid(), (SELECT id FROM preference_types WHERE code = ''INTEREST''), ''CAFE'', ''카페'', ''https://sometimes-resources.s3.ap-northeast-2.amazonaws.com/icons/cafe.png'', 9, false, NOW(), NOW()
+WHERE NOT EXISTS (SELECT 1 FROM preference_options po JOIN preference_types pt ON po.preference_type_id = pt.id WHERE pt.code = ''INTEREST'' AND po.value = ''CAFE'')
+UNION ALL
+SELECT gen_random_uuid(), (SELECT id FROM preference_types WHERE code = ''INTEREST''), ''PERFORMANCE'', ''공연'', ''https://sometimes-resources.s3.ap-northeast-2.amazonaws.com/icons/festival.png'', 10, false, NOW(), NOW()
+WHERE NOT EXISTS (SELECT 1 FROM preference_options po JOIN preference_types pt ON po.preference_type_id = pt.id WHERE pt.code = ''INTEREST'' AND po.value = ''PERFORMANCE'')
+UNION ALL
+SELECT gen_random_uuid(), (SELECT id FROM preference_types WHERE code = ''INTEREST''), ''EXHIBITION'', ''전시'', ''https://sometimes-resources.s3.ap-northeast-2.amazonaws.com/icons/pictures.png'', 11, false, NOW(), NOW()
+WHERE NOT EXISTS (SELECT 1 FROM preference_options po JOIN preference_types pt ON po.preference_type_id = pt.id WHERE pt.code = ''INTEREST'' AND po.value = ''EXHIBITION'')
+UNION ALL
+SELECT gen_random_uuid(), (SELECT id FROM preference_types WHERE code = ''INTEREST''), ''PETS'', ''반려동물'', ''https://sometimes-resources.s3.ap-northeast-2.amazonaws.com/icons/pet.png'', 12, false, NOW(), NOW()
+WHERE NOT EXISTS (SELECT 1 FROM preference_options po JOIN preference_types pt ON po.preference_type_id = pt.id WHERE pt.code = ''INTEREST'' AND po.value = ''PETS'')
+UNION ALL
+SELECT gen_random_uuid(), (SELECT id FROM preference_types WHERE code = ''INTEREST''), ''HIKING'', ''등산'', ''https://sometimes-resources.s3.ap-northeast-2.amazonaws.com/icons/hiking.png'', 13, false, NOW(), NOW()
+WHERE NOT EXISTS (SELECT 1 FROM preference_options po JOIN preference_types pt ON po.preference_type_id = pt.id WHERE pt.code = ''INTEREST'' AND po.value = ''HIKING'')
+UNION ALL
+SELECT gen_random_uuid(), (SELECT id FROM preference_types WHERE code = ''INTEREST''), ''CYCLING'', ''자전거'', ''https://sometimes-resources.s3.ap-northeast-2.amazonaws.com/icons/sports.png'', 14, false, NOW(), NOW()
+WHERE NOT EXISTS (SELECT 1 FROM preference_options po JOIN preference_types pt ON po.preference_type_id = pt.id WHERE pt.code = ''INTEREST'' AND po.value = ''CYCLING'');
+
+-- preference_options 데이터 삽입 - MBTI 유형 (MBTI)
+INSERT INTO preference_options (id, preference_type_id, value, display_name, "order", deprecated, created_at, updated_at)
+SELECT gen_random_uuid(), (SELECT id FROM preference_types WHERE code = ''MBTI''), ''INTJ'', ''INTJ'', 0, false, NOW(), NOW()
+WHERE NOT EXISTS (SELECT 1 FROM preference_options po JOIN preference_types pt ON po.preference_type_id = pt.id WHERE pt.code = ''MBTI'' AND po.value = ''INTJ'')
+UNION ALL
+SELECT gen_random_uuid(), (SELECT id FROM preference_types WHERE code = ''MBTI''), ''INTP'', ''INTP'', 1, false, NOW(), NOW()
+WHERE NOT EXISTS (SELECT 1 FROM preference_options po JOIN preference_types pt ON po.preference_type_id = pt.id WHERE pt.code = ''MBTI'' AND po.value = ''INTP'')
+UNION ALL
+SELECT gen_random_uuid(), (SELECT id FROM preference_types WHERE code = ''MBTI''), ''ENTJ'', ''ENTJ'', 2, false, NOW(), NOW()
+WHERE NOT EXISTS (SELECT 1 FROM preference_options po JOIN preference_types pt ON po.preference_type_id = pt.id WHERE pt.code = ''MBTI'' AND po.value = ''ENTJ'')
+UNION ALL
+SELECT gen_random_uuid(), (SELECT id FROM preference_types WHERE code = ''MBTI''), ''ENTP'', ''ENTP'', 3, false, NOW(), NOW()
+WHERE NOT EXISTS (SELECT 1 FROM preference_options po JOIN preference_types pt ON po.preference_type_id = pt.id WHERE pt.code = ''MBTI'' AND po.value = ''ENTP'')
+UNION ALL
+SELECT gen_random_uuid(), (SELECT id FROM preference_types WHERE code = ''MBTI''), ''INFJ'', ''INFJ'', 4, false, NOW(), NOW()
+WHERE NOT EXISTS (SELECT 1 FROM preference_options po JOIN preference_types pt ON po.preference_type_id = pt.id WHERE pt.code = ''MBTI'' AND po.value = ''INFJ'')
+UNION ALL
+SELECT gen_random_uuid(), (SELECT id FROM preference_types WHERE code = ''MBTI''), ''INFP'', ''INFP'', 5, false, NOW(), NOW()
+WHERE NOT EXISTS (SELECT 1 FROM preference_options po JOIN preference_types pt ON po.preference_type_id = pt.id WHERE pt.code = ''MBTI'' AND po.value = ''INFP'')
+UNION ALL
+SELECT gen_random_uuid(), (SELECT id FROM preference_types WHERE code = ''MBTI''), ''ENFJ'', ''ENFJ'', 6, false, NOW(), NOW()
+WHERE NOT EXISTS (SELECT 1 FROM preference_options po JOIN preference_types pt ON po.preference_type_id = pt.id WHERE pt.code = ''MBTI'' AND po.value = ''ENFJ'')
+UNION ALL
+SELECT gen_random_uuid(), (SELECT id FROM preference_types WHERE code = ''MBTI''), ''ENFP'', ''ENFP'', 7, false, NOW(), NOW()
+WHERE NOT EXISTS (SELECT 1 FROM preference_options po JOIN preference_types pt ON po.preference_type_id = pt.id WHERE pt.code = ''MBTI'' AND po.value = ''ENFP'')
+UNION ALL
+SELECT gen_random_uuid(), (SELECT id FROM preference_types WHERE code = ''MBTI''), ''ISTJ'', ''ISTJ'', 8, false, NOW(), NOW()
+WHERE NOT EXISTS (SELECT 1 FROM preference_options po JOIN preference_types pt ON po.preference_type_id = pt.id WHERE pt.code = ''MBTI'' AND po.value = ''ISTJ'')
+UNION ALL
+SELECT gen_random_uuid(), (SELECT id FROM preference_types WHERE code = ''MBTI''), ''ISFJ'', ''ISFJ'', 9, false, NOW(), NOW()
+WHERE NOT EXISTS (SELECT 1 FROM preference_options po JOIN preference_types pt ON po.preference_type_id = pt.id WHERE pt.code = ''MBTI'' AND po.value = ''ISFJ'')
+UNION ALL
+SELECT gen_random_uuid(), (SELECT id FROM preference_types WHERE code = ''MBTI''), ''ESTJ'', ''ESTJ'', 10, false, NOW(), NOW()
+WHERE NOT EXISTS (SELECT 1 FROM preference_options po JOIN preference_types pt ON po.preference_type_id = pt.id WHERE pt.code = ''MBTI'' AND po.value = ''ESTJ'')
+UNION ALL
+SELECT gen_random_uuid(), (SELECT id FROM preference_types WHERE code = ''MBTI''), ''ESFJ'', ''ESFJ'', 11, false, NOW(), NOW()
+WHERE NOT EXISTS (SELECT 1 FROM preference_options po JOIN preference_types pt ON po.preference_type_id = pt.id WHERE pt.code = ''MBTI'' AND po.value = ''ESFJ'')
+UNION ALL
+SELECT gen_random_uuid(), (SELECT id FROM preference_types WHERE code = ''MBTI''), ''ISTP'', ''ISTP'', 12, false, NOW(), NOW()
+WHERE NOT EXISTS (SELECT 1 FROM preference_options po JOIN preference_types pt ON po.preference_type_id = pt.id WHERE pt.code = ''MBTI'' AND po.value = ''ISTP'')
+UNION ALL
+SELECT gen_random_uuid(), (SELECT id FROM preference_types WHERE code = ''MBTI''), ''ISFP'', ''ISFP'', 13, false, NOW(), NOW()
+WHERE NOT EXISTS (SELECT 1 FROM preference_options po JOIN preference_types pt ON po.preference_type_id = pt.id WHERE pt.code = ''MBTI'' AND po.value = ''ISFP'')
+UNION ALL
+SELECT gen_random_uuid(), (SELECT id FROM preference_types WHERE code = ''MBTI''), ''ESTP'', ''ESTP'', 14, false, NOW(), NOW()
+WHERE NOT EXISTS (SELECT 1 FROM preference_options po JOIN preference_types pt ON po.preference_type_id = pt.id WHERE pt.code = ''MBTI'' AND po.value = ''ESTP'')
+UNION ALL
+SELECT gen_random_uuid(), (SELECT id FROM preference_types WHERE code = ''MBTI''), ''ESFP'', ''ESFP'', 15, false, NOW(), NOW()
+WHERE NOT EXISTS (SELECT 1 FROM preference_options po JOIN preference_types pt ON po.preference_type_id = pt.id WHERE pt.code = ''MBTI'' AND po.value = ''ESFP'');
+
+-- preference_options 데이터 삽입 - 선호 나이대 (AGE_PREFERENCE)
+INSERT INTO preference_options (id, preference_type_id, value, display_name, "order", deprecated, created_at, updated_at)
+SELECT gen_random_uuid(), (SELECT id FROM preference_types WHERE code = ''AGE_PREFERENCE''), ''OLDER'', ''연상'', 0, false, NOW(), NOW()
+WHERE NOT EXISTS (SELECT 1 FROM preference_options po JOIN preference_types pt ON po.preference_type_id = pt.id WHERE pt.code = ''AGE_PREFERENCE'' AND po.value = ''OLDER'')
+UNION ALL
+SELECT gen_random_uuid(), (SELECT id FROM preference_types WHERE code = ''AGE_PREFERENCE''), ''YOUNGER'', ''연하'', 1, false, NOW(), NOW()
+WHERE NOT EXISTS (SELECT 1 FROM preference_options po JOIN preference_types pt ON po.preference_type_id = pt.id WHERE pt.code = ''AGE_PREFERENCE'' AND po.value = ''YOUNGER'')
+UNION ALL
+SELECT gen_random_uuid(), (SELECT id FROM preference_types WHERE code = ''AGE_PREFERENCE''), ''SAME_AGE'', ''동갑'', 2, false, NOW(), NOW()
+WHERE NOT EXISTS (SELECT 1 FROM preference_options po JOIN preference_types pt ON po.preference_type_id = pt.id WHERE pt.code = ''AGE_PREFERENCE'' AND po.value = ''SAME_AGE'')
+UNION ALL
+SELECT gen_random_uuid(), (SELECT id FROM preference_types WHERE code = ''AGE_PREFERENCE''), ''NO_PREFERENCE'', ''상관없음'', 3, false, NOW(), NOW()
+WHERE NOT EXISTS (SELECT 1 FROM preference_options po JOIN preference_types pt ON po.preference_type_id = pt.id WHERE pt.code = ''AGE_PREFERENCE'' AND po.value = ''NO_PREFERENCE'');s.s3.ap-northeast-2.amazonaws.com/icons/gaming.png'),
   (gen_random_uuid(), (SELECT id FROM interest), 'SPORTS', '운동', NOW(), NOW(), 'https://sometimes-resources.s3.ap-northeast-2.amazonaws.com/icons/exercise.png'),
   (gen_random_uuid(), (SELECT id FROM interest), 'COOKING', '요리', NOW(), NOW(), 'https://sometimes-resources.s3.ap-northeast-2.amazonaws.com/icons/cooking.png'),
   (gen_random_uuid(), (SELECT id FROM interest), 'TRAVEL', '여행', NOW(), NOW(), 'https://sometimes-resources.s3.ap-northeast-2.amazonaws.com/icons/travel.png'),

--- a/src/database/schema/preference_options.ts
+++ b/src/database/schema/preference_options.ts
@@ -1,4 +1,4 @@
-import { pgTable, varchar, text } from 'drizzle-orm/pg-core';
+import { pgTable, varchar, text, integer, boolean } from 'drizzle-orm/pg-core';
 import { uuid, timestamps } from './helper';
 
 export const preferenceOptions = pgTable('preference_options', {
@@ -6,6 +6,8 @@ export const preferenceOptions = pgTable('preference_options', {
   imageUrl: text('image_url'),
   preferenceTypeId: varchar('preference_type_id', { length: 128 }),
   value: varchar('value', { length: 100 }).notNull(),
+  order: integer().notNull().default(0),
   displayName: varchar('display_name', { length: 100 }).notNull(),
+  deprecated: boolean().notNull().default(true),
   ...timestamps,
 });

--- a/src/user/repository/profile.repository.ts
+++ b/src/user/repository/profile.repository.ts
@@ -184,6 +184,7 @@ export default class ProfileRepository {
               userPreference.id,
             ),
             eq(schema.userPreferenceOptions.preferenceTarget, who),
+            eq(schema.preferenceOptions.deprecated, false),
           ),
         )
         .orderBy(asc(schema.preferenceOptions.order));
@@ -220,7 +221,12 @@ export default class ProfileRepository {
         ),
       )
       .orderBy(schema.preferenceTypes.code, asc(schema.preferenceOptions.order))
-      .where(inArray(schema.preferenceTypes.code, CASES));
+      .where(
+        and(
+          inArray(schema.preferenceTypes.code, CASES),
+          eq(schema.preferenceOptions.deprecated, false),
+        ),
+      );
   }
 
   async updatePreferences(userId: string, data: PreferenceSave['data']) {
@@ -417,6 +423,7 @@ export default class ProfileRepository {
               schema.userPreferenceOptions.preferenceTarget,
               PreferenceTarget.SELF,
             ),
+            eq(schema.preferenceOptions.deprecated, false),
           ),
         )
         .orderBy(asc(schema.preferenceOptions.order));

--- a/src/user/repository/profile.repository.ts
+++ b/src/user/repository/profile.repository.ts
@@ -5,6 +5,7 @@ import * as schema from '@database/schema';
 import { PreferenceTarget } from '@database/schema';
 import {
   and,
+  asc,
   eq,
   ExtractTablesWithRelations,
   inArray,
@@ -184,7 +185,8 @@ export default class ProfileRepository {
             ),
             eq(schema.userPreferenceOptions.preferenceTarget, who),
           ),
-        );
+        )
+        .orderBy(asc(schema.preferenceOptions.order));
     });
   }
 
@@ -217,7 +219,7 @@ export default class ProfileRepository {
           schema.preferenceTypes.id,
         ),
       )
-      .orderBy(schema.preferenceTypes.code)
+      .orderBy(schema.preferenceTypes.code, asc(schema.preferenceOptions.order))
       .where(inArray(schema.preferenceTypes.code, CASES));
   }
 
@@ -416,7 +418,8 @@ export default class ProfileRepository {
               PreferenceTarget.SELF,
             ),
           ),
-        );
+        )
+        .orderBy(asc(schema.preferenceOptions.order));
     });
   }
 


### PR DESCRIPTION
## Summary
- preference_options 테이블에 order, deprecated 컬럼 추가로 UI 순서 제어 및 이전 데이터 호환성 확보
- 전체 선호도 옵션 데이터 정리 및 초기 데이터 구축
- 레포지토리 쿼리 개선으로 deprecated 옵션 필터링 및 순서 정렬 적용

## 주요 변경사항
- **스키마 변경**: preference_options 테이블에 order(정렬), deprecated(호환성) 컬럼 추가
- **데이터 정리**: 기존 데이터에 order 값 부여 및 deprecated=false 설정
- **초기 데이터**: 전체 선호도 카테고리(성격, 연애스타일, 라이프스타일, 음주/흡연/문신, 관심사, MBTI, 나이대) 포함
- **쿼리 개선**: 순서 정렬 및 deprecated 옵션 필터링 적용

## 기술적 개선
- WHERE NOT EXISTS 패턴으로 중복 방지 UPSERT 구현
- 환경별 데이터 일관성을 위한 preference_type 코드 기반 조회
- order 기반 ASC 정렬로 UI 표시 순서 제어

## Test plan
- [ ] 기존 API 호출 시 deprecated=false 옵션만 조회되는지 확인
- [ ] 선호도 옵션이 설정된 order 순서대로 반환되는지 확인
- [ ] initial_data.sql 실행으로 모든 카테고리 데이터가 정상 생성되는지 확인

🤖 Generated with [Claude Code](https://claude.ai/code)